### PR TITLE
Change the compile target to ES2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This library also provides a convenient way to handle them and its way is inspir
 We target to run in following environments.
 
 - Language
-    - [ECMA262 5th edition](https://262.ecma-international.org/5.1/).
+    - [ECMA262 2017 edition](https://262.ecma-international.org/8.0/).
     - TypeScript's latest version.
 - Module system
     - ES Module ([ES2015](https://262.ecma-international.org/6.0/) level).
@@ -122,8 +122,9 @@ We target to run in following environments.
 
 1. Your code may work with this package even if your project does not supports all of these requirements.
    But we may not be able to support such environments officially. We recommend to update your environment generally.
-2. If you would like to work this packages for a more legacy environment (e.g. ES3!)
+2. If you would like to work this packages for a more legacy environment (e.g. ES2016 or earlier)
    we recommend to transform whole of codes including your dependencies in your build pipeline.
+    - If you need to support ES5 environment, you can use [**`v37`**](https://github.com/option-t/option-t/tree/v37.2.1) too.
 3. If your project still use TypeScript's `--moduleResolution` with `node/node10` setting, please use [**`v35`**](https://github.com/option-t/option-t/tree/v35.0.0).
 
 
@@ -132,6 +133,10 @@ We target to run in following environments.
 
 ```sh
 npm install --save option-t
+
+# If you need to supports an environment that does not support ES2017
+# without any transform whole of programs including dependencies.
+npm install --save option-t@^37
 
 # If your project still...
 #   1. Use TypeScript with `--moduleResolution node` or `--moduleResolution node10` setting.

--- a/packages/option-t/tools/babel/babelconfig.mjs
+++ b/packages/option-t/tools/babel/babelconfig.mjs
@@ -1,14 +1,44 @@
 export const babelEnvPresetConfig = {
+    // The final generated code will align to the oldest target of followings.
     targets: {
-        // Our targeted low-end environment is still IE11.
-        // But this is simple that we only requires ES5 and our package does not require post ES6 features at now.
-        // This means that it's not a hard to ship a code to IE11, at least now.
-        // If we need post ES6 features, then we would ship transformed code to IE11.
+        // We should keep this field conservatively to avoid any syntax changes.
+        // This would be a key person of this list for almost cases.
+        // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
+        node: '8', // ES2017
+        // Sort with Firefox ESR.
+        // https://wiki.mozilla.org/Release_Management/Calendar
+        firefox: '102',
+        // Sort with ChromeOS' LTS.
+        // https://support.google.com/chrome/a/answer/11333726?hl=en
+        chrome: '102',
+        // We cannot know Safari's policy about thier lifecycle due to Apple does not say about it explictly.
+        // But we can read about it implicitly by their software release and by their abandanant a security fix.
         //
-        // Chakra bundled with IE9 almost supports ES5. So this package ~IE9 might work on it.
-        // But we'll not ensure to support IE9.
-        ie: '11',
-        node: '8',
+        // For example,
+        //
+        //  1. WebKit removed macOS Catalina support at Aug. 2022.
+        //      - https://github.com/WebKit/WebKit/commit/677b453daf6855bb2601d776532503e1c07ddc90
+        //      - https://github.com/WebKit/WebKit/commit/3ae8891d52913a34e3338f9b531a23bf3e55cbb7
+        //  2. macOS Catalina is the oldest version running with Safari 15.
+        //     Safari 16 does not support macOS Catalina.
+        //     https://en.wikipedia.org/wiki/Safari_(web_browser)
+        //  3. macOS Catalina is the oldest version that Safari 15 runs
+        //     and Apple don't release any update for Catalina after that
+        //     even though there are bunch of security fixes included in newer versions of Apple OSes released as stable.
+        //     https://en.wikipedia.org/wiki/MacOS_Catalina#Release_history
+        //  4. For iOS, iPadOS, and others, Apple releases a security update only for latest major versions of them.
+        //      - We can regard Apple does not support old major versions for that basically.
+        //      - Of course, there are some exceptins.
+        //          - Apple released security patch for iOS 15 in Jan. 2023.
+        //          - We know Apple still release a security patch for iOS 12.x occasionally
+        //
+        // From above, at this moment (Spring 2023),
+        // we can think that Apple supports latest one or (latest - 1) version that they will get a security fix.
+        //
+        // Of course, strictly, each of applications need to judge by their user metrics.
+        // But we can consider to support a version expected to get a chance to receive a security fix.
+        // By contrasts, we can drop older version looked as that Apple abandon to provide a security fix.
+        safari: '15.6',
     },
     spec: false,
     loose: true,

--- a/packages/option-t/tsconfig.json
+++ b/packages/option-t/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "target": "es5",
+        // See also packages/option-t/tools/babel/babelconfig.mjs
+        "target": "ES2017",
         "module": "es2015",
         "declaration": true,
         "lib": [


### PR DESCRIPTION
Fix https://github.com/karen-irc/option-t/issues/1236

We choose ES2017 because:

1. We use `exports` in pacakge.json heavily. This feature is supported since Node.js v12.
   We need choose Node.js v12 or earlier.
2. We would like to use async function without any down level transform.
3. We would like to keep syntax level change minimally.