### PR TITLE
Do not emit `exports.__esModule` for commonjs

### DIFF
--- a/packages/option-t/tools/babel/babelrc.cjs.mjs
+++ b/packages/option-t/tools/babel/babelrc.cjs.mjs
@@ -20,6 +20,7 @@ export default {
         }],
         ['@babel/plugin-transform-modules-commonjs', {
             importInterop: 'none',
+            strict: true,
         }]
     ],
 };


### PR DESCRIPTION
Fix #1519

We'd like to simplify an generated code. We think this would not be impactful because ES Module is common way now.