### PR TITLE
Drop to mention about `option-t/lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,6 @@ If you're project cannot import by their path, please read [this guide](./docs/h
 import { isNotNull } from 'option-t/Nullable';
 import { unwrapNullable } from 'option-t/Nullable/unwrap';
 import { createOk, isOk } from 'option-t/PlainResult';
-
-// If your toolchains supports package.json's exports field (if you fail to import by the above style)
-import { isNotNull } from 'option-t/lib/Nullable';
-import { unwrapNullable } from 'option-t/lib/Nullable/unwrap';
-import { createOk, isOk } from 'option-t/lib/PlainResult';
 ```
 
 

--- a/docs/how_to_import.md
+++ b/docs/how_to_import.md
@@ -11,38 +11,41 @@ Each of them includes the same directory hierarchy with [under `src`/](../packag
 import { isNotNull } from 'option-t/Nullable';
 import { unwrapNullable } from 'option-t/Nullable/unwrap';
 import { createOk, isOk } from 'option-t/PlainResult';
-
-// If your toolchains supports package.json's exports field
-// (if you fail to import by the above style)
-import { isNotNull } from 'option-t/lib/Nullable';
-import { unwrapNullable } from 'option-t/lib/Nullable/unwrap';
-import { createOk, isOk } from 'option-t/lib/PlainResult';
 ```
 
 
 ## If your toolchain _does not_ support `exports` field in package.json...
 
-We provides some backward compatible styles. __They are *deprecated* but we're no plan to drop them.__
-
+We provides some backward compatible styles.
 _These styles are kept for backward compatibility. You should switch to `option-t/BarFoo` style path_.
 
+### Case: Your project uses a classic bundler or type checker options which does not support `exports` field.
 
-### Case: Your project is still use TypeScript compiler which lacks to support `moduleResolution=node16` or similar options
+For example, these classic tools or classic options are not support `exports` field of package.json
 
-Use `option-t/lib/**`.
+- webpack v4 or earlier.
+- TypeScript with `--moduleResolution node`.
+    - TypeScript v4.6 or earlier only have this option.
+- or etc.
 
-This directory provides both of an ES Module and a CommonJS style module by
-[conditional exports](https://nodejs.org/api/packages.html#conditional-exports)
-and host an actual `d.ts` file for legacy TypeScript compiler.
-
-This is a most easy path for migrations (e.g. switch to `option-t/BarFoo` style, or switch to ES Module from CommonJS).
-
-
-### Case: Your project uses a classic bundler which does not support `exports` field.
-
-you can use these paths:
+Then, you can use these paths:
 
 - `option-t/cjs/**` (__*Deprecated*__)
    - This directory provides only commonjs style modules.
+   - You can use this path _to import as commonjs forcefully_.
 - `option-t/esm/**` (__*Deprecated*__)
    - This directory privides only ES Modules.
+   - You can use this path _to import as ES Module forcefully_.
+
+```js
+// If your toolchains supports package.json's exports field
+import { isNotNull } from 'option-t/esm/Nullable';
+import { unwrapNullable } from 'option-t/esm/Nullable/unwrap';
+import { createOk, isOk } from 'option-t/esm/PlainResult';
+
+// or
+
+const { isNotNull } = require('option-t/cjs/Nullable');
+const { unwrapNullable } = require('option-t/cjs/Nullable/unwrap');
+const { createOk, isOk } = require('option-t/cjs/PlainResult');
+```

--- a/docs/public_api_list.md
+++ b/docs/public_api_list.md
@@ -2,8 +2,6 @@
 
 - You can import these paths from both `require()` and `import()`.
 - To import these, your toolchains must support [package.json's conditional exports](https://nodejs.org/api/esm.html#esm_conditional_exports).
-    - If your toolchains does not support package json's conditional exports, use `option-t/lib/**`  path pattern. (e.g. `option-t/lib/Nullable/map`)
-
 
 ## Maybe
 

--- a/packages/option-t/tools/generate_import_path_list_markdown.mjs
+++ b/packages/option-t/tools/generate_import_path_list_markdown.mjs
@@ -115,8 +115,6 @@ function generateText(list) {
 
 - You can import these paths from both \`require()\` and \`import()\`.
 - To import these, your toolchains must support [package.json's conditional exports](https://nodejs.org/api/esm.html#esm_conditional_exports).
-    - If your toolchains does not support package json's conditional exports, use \`option-t/lib/**\`  path pattern. (e.g. \`option-t/lib/Nullable/map\`)
-
 ${str}
 `;
 }


### PR DESCRIPTION
`option-t/lib` was a migration compat path to do same thing as dual exports with tsc's `--moduleResolution node` (or `node10`).

Now, we drop to support its style completely. We should drop to mention about it from our docs.