### PR TITLE
Add `deprecated` jsdoc tag to `PlainOption/index` and `PlainOption/namespace`

### DIFF
--- a/packages/option-t/src/plain_option/index.ts
+++ b/packages/option-t/src/plain_option/index.ts
@@ -1,4 +1,10 @@
 /**
+ *  @deprecated
+ *  Consider to use `Nullable<T>`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value.
+ *  In JavaScript, they satisfy almost use cases. Probably, you might not have to use this type.
+ *
+ *  --------
+ *
  *  This module provies that the Option type interface whose APIs are inspired
  *  by Rust's [`std::option::Option<T>`](https://doc.rust-lang.org/std/option/index.html).
  *

--- a/packages/option-t/src/plain_option/namespace.ts
+++ b/packages/option-t/src/plain_option/namespace.ts
@@ -1,4 +1,10 @@
 /**
+ *  @deprecated
+ *  Consider to use `Nullable<T>`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value.
+ *  In JavaScript, they satisfy almost use cases. Probably, you might not have to use this type.
+ *
+ *  --------
+ *
  *  XXX:
  *  This module is designed to use as `import * as PlainOption from 'option-t/PlainOption/namespace';`.
  *  This is not designed for other usecases. Please do not use for other cases.


### PR DESCRIPTION
see https://github.com/option-t/option-t/pull/1535