### PR TITLE
Deprecate `PlainOption<T>` officially

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ All APIs are TypeScript ready.
     * [`Maybe<T>` (`T | null | undefined`)](./docs/public_api_list.md#maybe)
     * plain objects
         * [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./docs/public_api_list.md#plainresult)
-        * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./docs/public_api_list.md#plainoption) (_weak deprecated_)
+        * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./docs/public_api_list.md#plainoption) (_deprecated_)
 * [Wrapper objects](./docs/wrapper_objects.md) ([__*deprecated*__](https://github.com/option-t/option-t/issues/459)).
 
 Additional documents are in [`docs/`](./docs/).

--- a/docs/deprecated_apis.md
+++ b/docs/deprecated_apis.md
@@ -14,7 +14,7 @@ They are marked as `@deprecated` but there are not in the next "As Not Recommend
 We don't have any concrete plan to remove followings but do not recommend to use them in almost cases.
 
 
-###  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](../docs/public_api_list.md#plainoption) (weak deprecated)
+###  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](../docs/public_api_list.md#plainoption) (deprecated)
 
 **Basically, we don't recommend to use this type. Use `Nullable`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value instead. In JavaScript, they would cover almost usecases. Probably, you might not have to use this type.**
 


### PR DESCRIPTION
We deprecated `PlainOption` weakly in #1535 (released in [v33.2.0](https://github.com/option-t/option-t/releases/tag/v33.2.0)).

This API still useful if you would like to contain a null value as a some value (e.g. `Some<null | undefined>`).
However, I think it's rare case in JavaScript generally.

At this time, we mark it deprecated officially. **This does not mean that we remove this API.**