### PR TITLE
Use actions/setup-node instead of running everything in the docker container.

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -1,9 +1,28 @@
 name: Prepare CI
 description: This action prepare CI that restore cachable items
 
+inputs:
+    node-version:
+        required: true
+
 runs:
     using: composite
     steps:
+        # Ideally, we run every CI jobs in some containers as a hermetic to make it easy to reproduce the environment locally.
+        # However,
+        #   1. Recently, it is delayed to update of Node.js' docker image.
+        #      This would not be a high impact problem but this is a remarkable problem for major version.
+        #      It sometimes 3~4 weeks delay. We cannot test with a new version immidiately.
+        #   2. Old actions/setup-node (v1) cannot install the Node.js that is not listed in the action's database.
+        #      It's slower than a docker image. See https://github.com/option-t/option-t/pull/681#issuecomment-658219488
+        #      But the recent version of its GH action does not such problem.
+        #   3. GH Action job is enough to hermetic to achieve, I think. Any fork can them in their forked repository,
+        #      and each of steps of them are almost portable to reproduce them for this project's purpose.
+        # So we use `actions/setup-node` simply.
+        - name: Setup Node.js
+          uses: actions/setup-node@v3
+          with:
+              node-version: ${{ inputs.node-version }}
         - name: Get npm cache directory
           shell: bash
           id: npm-cache-dir

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -12,7 +12,6 @@ permissions:
 jobs:
     warmup_dependency_cache:
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -24,11 +23,12 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
+              with:
+                  node-version: ${{ matrix.node-version }}
 
     format_check:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -38,7 +38,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
-
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make format_check -j
               env:
                   CI: true
@@ -46,7 +47,6 @@ jobs:
     lint:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -56,7 +56,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
-
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make lint -j
               env:
                   CI: true
@@ -64,7 +65,6 @@ jobs:
     build:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -74,7 +74,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
-
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make build -j
               env:
                   CI: true
@@ -82,7 +83,6 @@ jobs:
     unittest:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -92,7 +92,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
-
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make test_unittest -j
               env:
                   CI: true
@@ -100,7 +101,6 @@ jobs:
     test_package_json_exports_field_format:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -109,6 +109,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make test_package_json_exports_field_format -j
               env:
                   CI: true
@@ -116,7 +118,6 @@ jobs:
     test_import_types:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -125,6 +126,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make test_import_types -j
               env:
                   CI: true
@@ -132,7 +135,6 @@ jobs:
     test_distribution_contain_all:
         needs: [warmup_dependency_cache]
         runs-on: ubuntu-latest
-        container: node:${{ matrix.node-version }}-bullseye
 
         strategy:
             matrix:
@@ -142,7 +144,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
-
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: make test_distribution_contain_all -j
               env:
                   CI: true


### PR DESCRIPTION
This improves the CI workflow running time from [4m54s](https://github.com/option-t/option-t/actions/runs/4595920606/usage) to [3m55s](https://github.com/option-t/option-t/actions/runs/4596720291/usage). Each of jobs improves their startup times about 10sec.

This try again https://github.com/option-t/option-t/pull/681