### PR TITLE
Add the fallback path for `String(input)` failure in `assertIsErrorInstance()`

### DIFF
--- a/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error.test.mjs
@@ -49,3 +49,41 @@ test('input is Err, but the contained value is not Error', (t) => {
 
     t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
 });
+
+class CannotStringifyObject {
+    #error = null;
+    constructor(e) {
+        this.#error = e;
+    }
+
+    toString() {
+        throw this.#error;
+    }
+}
+
+test('input is Err, but the contained value is not Error and cannot stringify', (t) => {
+    t.plan(4);
+
+    const THROWN_IN_TO_STRING = new Error('cannot stringify!');
+    const ERROR_E = new CannotStringifyObject(THROWN_IN_TO_STRING);
+
+    const input = createErr(ERROR_E);
+    const thrown = t.throws(
+        () => {
+            unwrapOrThrowErrorFromResult(input);
+        },
+        {
+            instanceOf: TypeError,
+            message: `The contained E should be \`Error\` instance.`,
+        }
+    );
+
+    const thrownCause = thrown.cause;
+    t.is(thrownCause instanceof TypeError, true, `should be set Error.cause`);
+    t.is(
+        thrownCause.message,
+        `fail toString()`,
+        'should be set proper error message for Error.cause'
+    );
+    t.is(thrownCause.cause, THROWN_IN_TO_STRING, 'Error.cause.cause');
+});

--- a/packages/option-t/src/internal/assert.ts
+++ b/packages/option-t/src/internal/assert.ts
@@ -1,15 +1,46 @@
 import { ERR_MSG_INPUT_IS_FROZEN_NOT_CAST_TO_MUTABLE } from './error_message.js';
 
-export function assertIsErrorInstance(input: unknown, message: string): asserts input is Error {
-    const ok = input instanceof Error;
-    if (!ok) {
-        const stringified = String(input);
-        const msg = `${message} The actual is \`${stringified}\``;
-        // We don't throw Node's AssertionError because the code size will be larger.
-        throw new TypeError(msg, {
-            cause: input,
+interface StringifyResult {
+    cause: unknown;
+    text: string;
+}
+
+function tryToString(input: unknown, message: string): StringifyResult {
+    // We would not like to use `Nullable<T>` here to avoid complex module dependency cycle.
+    let caught: Error | null = null;
+    let stringified = '';
+
+    try {
+        stringified = String(input);
+    } catch (e) {
+        caught = new TypeError(`fail toString()`, {
+            cause: e,
         });
     }
+
+    const isSuccessStringify = !caught;
+    const cause = isSuccessStringify ? input : caught;
+    const text = isSuccessStringify ? `${message} The actual is \`${stringified}\`` : message;
+
+    return {
+        cause,
+        text,
+    };
+}
+
+export function assertIsErrorInstance(input: unknown, message: string): asserts input is Error {
+    const ok = input instanceof Error;
+    if (ok) {
+        return;
+    }
+
+    // FIXME: https://github.com/option-t/option-t/issues/1832
+    // We should only use `Error.prototype.cause`.
+    const { cause, text } = tryToString(input, message);
+    // We don't throw Node's AssertionError because the code size will be larger.
+    throw new TypeError(text, {
+        cause,
+    });
 }
 
 export function assertIsFrozen(input: unknown): void {


### PR DESCRIPTION
This relaxes the problem of that `String(input)` fails by `input` has `.toString()` but it fails.

Essentially, this is not our business. It would be  But we need to do this to avoid changes both of behavior and host environment requirement.