### PR TITLE
Remove unnecessary tests about calling `.toString()` and fail it in `assertIsErrorInstance()`

### DIFF
--- a/packages/api_tests/__tests__/plain_result/try_catch/try_catch_with_ensure_error.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/try_catch/try_catch_with_ensure_error.test.mjs
@@ -54,29 +54,3 @@ test('If producer throw non-Error-instance value', (t) => {
 
     t.is(actual.cause, EXPECT_THROWN, `should set Error.cause`);
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('If producer throw non-Error-instance and cannot stringify value', (t) => {
-    t.plan(3);
-
-    const EXPECT_THROWN = new CannotStringifyObject();
-    const thrown = t.throws(
-        () => {
-            tryCatchIntoResultWithEnsureError(() => {
-                t.pass();
-                throw EXPECT_THROWN;
-            });
-        },
-        {
-            instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
-        }
-    );
-
-    t.is(thrown.cause, EXPECT_THROWN, `should be set Error.cause`);
-});

--- a/packages/api_tests/__tests__/plain_result/try_catch/without_error_cause_support.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/try_catch/without_error_cause_support.test.mjs
@@ -43,29 +43,3 @@ test('If producer throw non-Error-instance value', (t) => {
 
     t.is(actual.cause, EXPECT_THROWN, `should set Error.cause`);
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('If producer throw non-Error-instance and cannot stringify value', (t) => {
-    t.plan(3);
-
-    const EXPECT_THROWN = new CannotStringifyObject();
-    const thrown = t.throws(
-        () => {
-            tryCatchIntoResultWithEnsureError(() => {
-                t.pass();
-                throw EXPECT_THROWN;
-            });
-        },
-        {
-            instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
-        }
-    );
-
-    t.is(thrown.cause, EXPECT_THROWN, `should be set Error.cause`);
-});

--- a/packages/api_tests/__tests__/plain_result/try_catch_async/try_catch_with_ensure_error_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/try_catch_async/try_catch_with_ensure_error_async.test.mjs
@@ -154,30 +154,3 @@ test('if producer is async function and throw a not-Error-instance value', async
 
     t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('if producer is async function and throw a not-Error-instance and cannot stringify value', async (t) => {
-    t.plan(3);
-
-    const THROWN_EXPECTED = new CannotStringifyObject();
-    const actual = await t.throwsAsync(
-        async () => {
-            await tryCatchIntoResultWithEnsureErrorAsync(async () => {
-                t.pass('producer is called');
-                throw THROWN_EXPECTED;
-            });
-            t.fail('unreachable here');
-        },
-        {
-            instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
-        }
-    );
-
-    t.is(actual.cause, THROWN_EXPECTED, `should be set Error.cause`);
-});

--- a/packages/api_tests/__tests__/plain_result/try_catch_async/without_error_cause_support.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/try_catch_async/without_error_cause_support.test.mjs
@@ -87,30 +87,3 @@ test('if producer is async function and throw a not-Error-instance value', async
 
     t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('if producer is async function and throw a not-Error-instance and cannot stringify value', async (t) => {
-    t.plan(3);
-
-    const THROWN_EXPECTED = new CannotStringifyObject();
-    const actual = await t.throwsAsync(
-        async () => {
-            await tryCatchIntoResultWithEnsureErrorAsync(async () => {
-                t.pass('producer is called');
-                throw THROWN_EXPECTED;
-            });
-            t.fail('unreachable here');
-        },
-        {
-            instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
-        }
-    );
-
-    t.is(actual.cause, THROWN_EXPECTED, `should be set Error.cause`);
-});

--- a/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error.test.mjs
@@ -47,27 +47,3 @@ test('input is Err, but the contained value is not Error', (t) => {
 
     t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('input is Err, but the contained value is not Error and cannot stringify', (t) => {
-    t.plan(2);
-
-    const ERROR_E = new CannotStringifyObject();
-    const input = createErr(ERROR_E);
-    const thrown = t.throws(
-        () => {
-            unwrapOrThrowErrorFromResult(input);
-        },
-        {
-            instanceOf: TypeError,
-            message: `The contained E should be \`Error\` instance.`,
-        }
-    );
-
-    t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
-});

--- a/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error_without_error_cause_support.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unwrap_or_throw_error_without_error_cause_support.test.mjs
@@ -43,27 +43,3 @@ test('input is Err, but the contained value is not Error', (t) => {
 
     t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
 });
-
-class CannotStringifyObject {
-    toString() {
-        throw new Error('cannot stringify!');
-    }
-}
-
-test('input is Err, but the contained value is not Error and cannot stringify', (t) => {
-    t.plan(2);
-
-    const ERROR_E = new CannotStringifyObject();
-    const input = createErr(ERROR_E);
-    const thrown = t.throws(
-        () => {
-            unwrapOrThrowErrorFromResult(input);
-        },
-        {
-            instanceOf: TypeError,
-            message: `The contained E should be \`Error\` instance.`,
-        }
-    );
-
-    t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
-});


### PR DESCRIPTION
By fc83496a090d6f10d78361e6736d5d40a9c2faae, we shifted to use `Error.cause` instead of calling `String(value)`.

Thus we don't have to keep them