### PR TITLE
Set `Error.cause` in `assertIsErrorInstance()` by hand if it is not implemented by the host environment

### DIFF
--- a/packages/api_tests/__tests__/PlainResult/try_catch/try_catch_with_ensure_error.test.mjs
+++ b/packages/api_tests/__tests__/PlainResult/try_catch/try_catch_with_ensure_error.test.mjs
@@ -48,9 +48,7 @@ test('If producer throw non-Error-instance value', (t) => {
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance. The actual is \`${String(
-                EXPECT_THROWN
-            )}\``,
+            message: `The thrown value is not an \`Error\` instance.`,
         }
     );
 

--- a/packages/api_tests/__tests__/PlainResult/try_catch_async/try_catch_with_ensure_error_async.test.mjs
+++ b/packages/api_tests/__tests__/PlainResult/try_catch_async/try_catch_with_ensure_error_async.test.mjs
@@ -121,9 +121,7 @@ test('if producer is normal function and reject a Promise with not-Error-instanc
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance. The actual is \`${String(
-                THROWN_EXPECTED
-            )}\``,
+            message: `The thrown value is not an \`Error\` instance.`,
         }
     );
 
@@ -145,9 +143,7 @@ test('if producer is normal function and throw a not-Error-instance value before
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance. The actual is \`${String(
-                THROWN_EXPECTED
-            )}\``,
+            message: `The thrown value is not an \`Error\` instance.`,
         }
     );
 
@@ -169,9 +165,7 @@ test('if producer is async function and throw a not-Error-instance value', async
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance. The actual is \`${String(
-                THROWN_EXPECTED
-            )}\``,
+            message: `The thrown value is not an \`Error\` instance.`,
         }
     );
 

--- a/packages/api_tests/__tests__/PlainResult/unwrap_or_throw_error.test.mjs
+++ b/packages/api_tests/__tests__/PlainResult/unwrap_or_throw_error.test.mjs
@@ -41,9 +41,7 @@ test('input is Err, but the contained value is not Error', (t) => {
         },
         {
             instanceOf: TypeError,
-            message: `The contained E should be \`Error\` instance. The actual is \`${String(
-                ERROR_E
-            )}\``,
+            message: `The contained E should be \`Error\` instance.`,
         }
     );
 

--- a/packages/option-t/src/PlainResult/unwrapOrThrowError.ts
+++ b/packages/option-t/src/PlainResult/unwrapOrThrowError.ts
@@ -11,6 +11,9 @@ import { unwrapErrFromResult, unwrapOkFromResult } from './unwrap.js';
  *
  *  This function is provided only to improve an interoperability with the world using "throw error" convention.
  *  __We do not recommend to use this function__.
+ *
+ *  This function requires `Error.cause` to carry the failure reason
+ *  if it is not an `Error` instance.
  */
 export function unwrapOrThrowErrorFromResult<T>(input: Result<T, Error>): T {
     if (isOk(input)) {


### PR DESCRIPTION
This is the backport of fc83496a090d6f10d78361e6736d5d40a9c2faae.