### PR TITLE
Add Node.js v20 to _unittest_ CI job

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -18,7 +18,7 @@ jobs:
                 node-version:
                     # We think that we don't have to specify all versions which we'd like to test
                     # because almost npm packages cares about platform but don't care about node's version.
-                    - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3
@@ -69,7 +69,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3
@@ -88,6 +88,7 @@ jobs:
             matrix:
                 node-version:
                     - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3
@@ -105,7 +106,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
@@ -122,7 +123,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
@@ -139,7 +140,7 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 18
+                    - 20
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
- Fix #1816
- This also updates other base build job to Node.js v20
- We ensure  the pure behavior of Node.js by _unittest_ job. We don't have to add the matrix to all jobs.