### PR TITLE
Generate provenance statements by npm cli's `--provenance` option

### DIFF
--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -9,6 +9,12 @@ jobs:
     build:
         runs-on: ubuntu-latest
 
+        permissions:
+            contents: read
+            # This is required for provenance
+            # see https://docs.npmjs.com/generating-provenance-statements
+            id-token: write
+
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci

--- a/packages/option-t/Makefile
+++ b/packages/option-t/Makefile
@@ -217,4 +217,4 @@ prepublish: ## Run some commands for 'npm run prepublish'
 
 .PHONY: publish
 publish: ## Run some commands for 'npm publish'
-	cd $(DIST_DIR) && npm publish
+	cd $(DIST_DIR) && npm publish --provenance --access public


### PR DESCRIPTION
see:

- https://docs.npmjs.com/cli/v9/commands/npm-publish#provenance
- https://docs.npmjs.com/generating-provenance-statements
- https://github.blog/2023-04-19-introducing-npm-package-provenance/