### PR TITLE
Update TypeScript to 5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "globals": "^13.20.0",
                 "picomatch": "^2.3.1",
                 "prettier": "^2.8.8",
-                "typescript": "^5.0.4"
+                "typescript": "^5.1.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -3712,16 +3712,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+            "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=12.20"
+                "node": ">=14.17"
             }
         },
         "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
         "globals": "^13.20.0",
         "picomatch": "^2.3.1",
         "prettier": "^2.8.8",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.3"
     }
 }


### PR DESCRIPTION
We don't mark this commit as a breaking change due to their release note: https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/