### PR TITLE
Switch dependabot's interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     - package-ecosystem: npm
       directory: "/"
       schedule:
-          interval: weekly
+          interval: monthly
       open-pull-requests-limit: 99
       labels:
           - A-dependency
@@ -18,7 +18,7 @@ updates:
     - package-ecosystem: github-actions
       directory: "/"
       schedule:
-          interval: weekly
+          interval: monthly
       open-pull-requests-limit: 99
       labels:
           - A-dependency


### PR DESCRIPTION
For our dependencies, weekly is a bit noisy.