### PR TITLE
CI: Enable `merge_group` event for merge queue

### DIFF
--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - "main"
+    merge_group:
 
 permissions:
     contents: read


### PR DESCRIPTION
We're experimenting the merge queue.

see:

- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions