### PR TITLE
ci: Run merge queue check only `merge_group` & `checks_requested` tyes for future change.

### DIFF
--- a/.github/workflows/ci_for_merge_queue.yaml
+++ b/.github/workflows/ci_for_merge_queue.yaml
@@ -1,7 +1,10 @@
-name: CI for Merge Queue.
+name: CI for Merge Queue
 
 on:
     merge_group:
+        # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
+        types:
+            - checks_requested
 
 permissions:
     contents: read


### PR DESCRIPTION
see:

> https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
> 
> More than one activity type triggers this event. Although only the checks_requested activity type is supported, specifying the activity type will keep your workflow specific if more activity types are added in the future.