### PR TITLE
Enable ESLint's `class-methods-use-this` rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,8 +4,12 @@ import { fileURLToPath } from 'node:url';
 import js from '@eslint/js';
 import globals from 'globals';
 
-import coreConfig from './tools/eslint/vendor/eslintrc_core.cjs';
-import * as prettierConfig from './tools/eslint/prettier.js';
+import {
+    rules as rulesForJavaScript,
+    createLanguageOptionsForModule,
+    createLanguageOptionsForCommonJS,
+} from './tools/eslint/javascript.js';
+import { linterOptions } from './tools/eslint/linter_option.js';
 import {
     createlanguageOptionsForTypeScript,
     config as configForTypeScript,
@@ -14,28 +18,15 @@ import {
 const THIS_FILE_NAME = fileURLToPath(import.meta.url);
 const THIS_DIR_NAME = path.dirname(THIS_FILE_NAME);
 
-const reportUnusedDisableDirectives = true;
 const ecmaVersion = 2022;
 
-const linterOptions = Object.freeze({
-    reportUnusedDisableDirectives,
+const languageOptionsForModule = createLanguageOptionsForModule(ecmaVersion, {
+    ...globals.nodeBuiltin,
 });
 
-const languageOptionsForModule = Object.freeze({
-    ecmaVersion,
-    sourceType: 'module',
-    globals: {
-        ...globals.nodeBuiltin,
-    },
-});
-
-const languageOptionsForCommonJS = Object.freeze({
-    ecmaVersion,
-    sourceType: 'commonjs',
-    globals: {
-        ...globals.node,
-        ...globals.commonjs,
-    },
+const languageOptionsForCommonJS = createLanguageOptionsForCommonJS(ecmaVersion, {
+    ...globals.node,
+    ...globals.commonjs,
 });
 
 // https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new
@@ -44,9 +35,7 @@ export default [
     {
         linterOptions,
         rules: {
-            ...coreConfig.rules,
-            ...prettierConfig.rules,
-
+            ...rulesForJavaScript,
             'no-unused-private-class-members': 'warn',
         },
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,6 @@ export default [
         linterOptions,
         rules: {
             ...rulesForJavaScript,
-            'no-unused-private-class-members': 'warn',
         },
     },
     {

--- a/packages/option-t/tools/public_api/exposed_path.mjs
+++ b/packages/option-t/tools/public_api/exposed_path.mjs
@@ -5,9 +5,15 @@ import { apiTable } from './table.mjs';
 
 const PKG_NAME = 'option-t';
 
-export class ExposedPath {
+class ExposedPath {
     #key;
     #descriptor;
+
+    /**
+     *  @protected
+     *  @type   {boolean}
+     */
+    _isForCompat = false;
 
     constructor(key, descriptor) {
         assert.ok(typeof key === 'string');
@@ -15,7 +21,7 @@ export class ExposedPath {
 
         this.#key = key;
         this.#descriptor = descriptor;
-        Object.freeze(this);
+        Object.seal(this);
     }
 
     name() {
@@ -46,7 +52,7 @@ export class ExposedPath {
     }
 
     isForCompat() {
-        return false;
+        return this._isForCompat;
     }
 
     isDeprecated() {
@@ -71,10 +77,8 @@ export class QuirksLegacyExposedPath extends ExposedPath {
         const compatKey = `${moduleType}/${key}`;
         const desc = modifyDescriptor(descriptor, moduleType);
         super(compatKey, desc);
-    }
-
-    isForCompat() {
-        return true;
+        this._isForCompat = true;
+        Object.freeze(this);
     }
 
     isESM() {

--- a/packages/option-t/tools/public_api/mod.mjs
+++ b/packages/option-t/tools/public_api/mod.mjs
@@ -1,6 +1,5 @@
 export {
     generateExposedPathSequence,
     generateLegacyExposedPathSequence,
-    ExposedPath,
     QuirksLegacyExposedPath,
 } from './exposed_path.mjs';

--- a/tools/eslint/javascript.js
+++ b/tools/eslint/javascript.js
@@ -4,6 +4,8 @@ import * as prettierConfig from './prettier.js';
 export const rules = Object.freeze({
     ...vendoredCoreConfig.rules,
     ...prettierConfig.rules,
+
+    'no-unused-private-class-members': 'warn',
 });
 
 export function createLanguageOptionsForModule(ecmaVersion, globals) {

--- a/tools/eslint/javascript.js
+++ b/tools/eslint/javascript.js
@@ -1,0 +1,25 @@
+import vendoredCoreConfig from './vendor/eslintrc_core.cjs';
+import * as prettierConfig from './prettier.js';
+
+export const rules = Object.freeze({
+    ...vendoredCoreConfig.rules,
+    ...prettierConfig.rules,
+});
+
+export function createLanguageOptionsForModule(ecmaVersion, globals) {
+    const option = Object.freeze({
+        ecmaVersion,
+        sourceType: 'module',
+        globals,
+    });
+    return option;
+}
+
+export function createLanguageOptionsForCommonJS(ecmaVersion, globals) {
+    const option = Object.freeze({
+        ecmaVersion,
+        sourceType: 'commonjs',
+        globals,
+    });
+    return option;
+}

--- a/tools/eslint/javascript.js
+++ b/tools/eslint/javascript.js
@@ -6,6 +6,24 @@ export const rules = Object.freeze({
     ...prettierConfig.rules,
 
     'no-unused-private-class-members': 'warn',
+
+    // In JavaScript, it's hard to minify a property that is on prototype chain.
+    // Typically, they appears as a pattern as class' instance method.
+    // We cannot remove or mangle a code like `a.foo()` style code
+    // without analysis for whole of programs including usages of reflection
+    // or identifying what item is a part of public interface.
+    //
+    // This rule bans a class instance method
+    // that does not touch any `this` to improve a possibility to minify a code.
+    //
+    // Additionally, after ES Module or CommonJS era (single module per single file),
+    // excluding the case to improve an API ergonomics or requirement to implement an object interface,
+    // we don't have to belong a function that does not touch `this` to a class as like as Java or C++.
+    //
+    // To get a chance to improve a code size performance,
+    // it's better that we should export a standalone function directly
+    // instead of a part of class if it does not affect an API ergonomics.
+    'class-methods-use-this': 'warn',
 });
 
 export function createLanguageOptionsForModule(ecmaVersion, globals) {

--- a/tools/eslint/linter_option.js
+++ b/tools/eslint/linter_option.js
@@ -1,0 +1,5 @@
+const reportUnusedDisableDirectives = true;
+
+export const linterOptions = Object.freeze({
+    reportUnusedDisableDirectives,
+});

--- a/tools/eslint/typescript.js
+++ b/tools/eslint/typescript.js
@@ -61,6 +61,33 @@ export const config = Object.freeze({
 
         [KEY_NAMING_CONVENTION]: newNamingConventionRule,
 
+        // In JavaScript, it's hard to minify a property that is on prototype chain.
+        // Typically, they appears as a pattern as class' instance method.
+        // We cannot remove or mangle a code like `a.foo()` style code
+        // without analysis for whole of programs including usages of reflection
+        // or identifying what item is a part of public interface.
+        //
+        // This rule bans a class instance method
+        // that does not touch any `this` to improve a possibility to minify a code.
+        //
+        // Additionally, after ES Module or CommonJS era (single module per single file),
+        // excluding the case to improve an API ergonomics or requirement to implement an object interface,
+        // we don't have to belong a function that does not touch `this` to a class as like as Java or C++.
+        //
+        // To get a chance to improve a code size performance,
+        // it's better that we should export a standalone function directly
+        // instead of a part of class if it does not affect an API ergonomics.
+        'class-methods-use-this': 'off',
+        '@typescript-eslint/class-methods-use-this': [
+            'warn',
+            {
+                // We would like to allow override the base method on super class.
+                ignoreOverrideMethods: true,
+                // We would like to allow to implement an empty method as a part of the interface.
+                ignoreClassesThatImplementAnInterface: true,
+            },
+        ],
+
         '@typescript-eslint/consistent-type-imports': [
             'warn',
             {

--- a/tools/eslint/vendor/eslintrc_core.cjs
+++ b/tools/eslint/vendor/eslintrc_core.cjs
@@ -97,7 +97,6 @@ module.exports = {
             'allowImplicit': false, // Should return `undefined` explicitly
         }],
         'block-scoped-var': 2, // https://eslint.org/docs/rules/block-scoped-var
-        'class-methods-use-this': 0, // A class method does not use `this` in some case.
         'complexity': 0, // We think there is no meaning to measure it in a daily linting.
         'consistent-return': 2,
         'curly': 2, // It's possible error to allow this.


### PR DESCRIPTION
In JavaScript, it's hard to minify a property that is on prototype chain. Typically, they appears as a pattern as class' instance method. We cannot remove or mangle a code like `a.foo()` style code without analysis for whole of programs including usages of reflection or identifying what item is a part of public interface.

This rule bans a class instance method that does not touch any `this` to improve a possibility to minify a code.

Additionally, after ES Module or CommonJS era (single module per single file), excluding the case to improve an API ergonomics or requirement to implement an object interface, we don't have to belong a function that does not touch `this` to a class as like as Java or C++.

To get a chance to improve a code size performance, it's better that we should export a standalone function directly instead of a part of class if it does not affect an API ergonomics.

See:

- https://eslint.org/docs/latest/rules/class-methods-use-this
- https://typescript-eslint.io/rules/class-methods-use-this/