### PR TITLE
Use reflink to copy files on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@babel/plugin-syntax-typescript": "^7.22.5",
                 "@babel/plugin-transform-modules-commonjs": "^7.23.0",
                 "@eslint/js": "^8.50.0",
+                "@reflink/reflink": "^0.1.12",
                 "@typescript-eslint/eslint-plugin": "^6.7.3",
                 "@typescript-eslint/parser": "^6.7.3",
                 "ava": "^5.3.1",
@@ -746,6 +747,153 @@
         "node_modules/@option-t/test_module_resolution_node16": {
             "resolved": "packages/test_module_resolution_node16",
             "link": true
+        },
+        "node_modules/@reflink/reflink": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.12.tgz",
+            "integrity": "sha512-ew/1rsLaPCUbBjP8caRzyCCAIEb+bNqlR5Tnco6UUk7P1oR3UfwGPdlJIJUqZrWDfhsoTV1I5APPe+w4zJJE0g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@reflink/reflink-darwin-arm64": "0.1.12",
+                "@reflink/reflink-darwin-x64": "0.1.12",
+                "@reflink/reflink-linux-arm64-gnu": "0.1.12",
+                "@reflink/reflink-linux-arm64-musl": "0.1.12",
+                "@reflink/reflink-linux-x64-gnu": "0.1.12",
+                "@reflink/reflink-linux-x64-musl": "0.1.12",
+                "@reflink/reflink-win32-arm64-msvc": "0.1.12",
+                "@reflink/reflink-win32-x64-msvc": "0.1.12"
+            }
+        },
+        "node_modules/@reflink/reflink-darwin-arm64": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.12.tgz",
+            "integrity": "sha512-vvxUYe1TxpVBhCOjpX1L7s+0HskBa4bKuG47vmsh9u3rqFoow6Lprgt9il34HoFMJsMfQ3vYtfNkwNTsehWGHw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-darwin-x64": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.12.tgz",
+            "integrity": "sha512-wg6P+J08q04jLUoc/GR0m9WVUH1Qzbnrosxwng5GRH0up0RfwUpK88tGWoarwwDmajMNUKy4s+OKwBO6OvBxcA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-linux-arm64-gnu": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.12.tgz",
+            "integrity": "sha512-g6iYC3NCRdgOwC5lrDKx3Urr4T4ZCzNaE1rVPzKyj7jFVPHUMAhUsfBtClt/705D47c8FGgQ/STP6rMHwBDERw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-linux-arm64-musl": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.12.tgz",
+            "integrity": "sha512-zOcwGiFbmBQBYAKabyTKENhg5vh4sY8I46ZGAODOFyNm2ojOov9zpuHkcg9FThhdy16CaI4ICAS8Iuzv+hkFLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-linux-x64-gnu": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.12.tgz",
+            "integrity": "sha512-A7tvkPCm2ct9ckpO95MUht0L9MFzSpRyMH73n4WjDEMJzqztVWlonzcjKQG1mC2FKoMB3DWprkm38i2hJIfUjQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-linux-x64-musl": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.12.tgz",
+            "integrity": "sha512-js2ymRLSzpvNHjDhLccEDrOlNIKHos6YRKLBrPXFDlRa1iqa1hfRsqWud5gU+JF1uyxhNPxAINT6sveyiEJNQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-win32-arm64-msvc": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.12.tgz",
+            "integrity": "sha512-fGoFaJR+qPjzcv+c2i9QpI3dy0s6JnfbtTrxUXfJMp/Lauod4r3K3zbWAGhbNW4C30ZoA1NZGIoME3m76a144Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@reflink/reflink-win32-x64-msvc": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.12.tgz",
+            "integrity": "sha512-sP8krmzDNrZ50yO+UxeLwjF8x8dq3JIb0cKwVhg7kImJrZguwiB/Y0c1aEfaBcliCLR5jcp47Dt9bI5EP8N1jg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.13",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "@babel/plugin-syntax-typescript": "^7.22.5",
         "@babel/plugin-transform-modules-commonjs": "^7.23.0",
         "@eslint/js": "^8.50.0",
+        "@reflink/reflink": "^0.1.12",
         "@typescript-eslint/eslint-plugin": "^6.7.3",
         "@typescript-eslint/parser": "^6.7.3",
         "ava": "^5.3.1",


### PR DESCRIPTION
macOS & APFS supports Copy-on-Write file operation via clonefile system call.
However, Node.js builtin `fs.copyFile()` does not support its syscall for a long time.

To avoid it and improve our build efficiency, we use a pnpm's approach that uses [`@reflink/reflink`](https://www.npmjs.com/package/@reflink/reflink). 

This code path is still only enabled for macOS.