### PR TITLE
Fix the path config for dependabot's `.github/actions/prepare_ci` watching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,12 +39,11 @@ updates:
           - A-dependency
           - I-dependency-gardening
 
-    ###
     ##################################################
     #   In-repository composite actions
     #####################################################
     - package-ecosystem: github-actions
-      directory: "/.github/actions/prepare_ci"
+      directory: "/.github/actions/prepare_ci/"
       schedule:
           interval: monthly
       open-pull-requests-limit: 99


### PR DESCRIPTION
This tries to fix dependabot watching. 

I guess dependabot cannot work correctly if we miss the trail `/`.