### PR TITLE
Revert "tools: Use `import.meta.filename` & `import.meta.dirname`"

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import js from '@eslint/js';
 import globals from 'globals';
@@ -15,7 +16,8 @@ import {
     config as configForTypeScript,
 } from './tools/eslint/typescript.js';
 
-const THIS_DIR_NAME = import.meta.dirname;
+const THIS_FILE_NAME = fileURLToPath(import.meta.url);
+const THIS_DIR_NAME = path.dirname(THIS_FILE_NAME);
 
 const ECMA262_VERSION = 2022;
 

--- a/packages/option-t/tools/babel/babelrc.cjs.mjs
+++ b/packages/option-t/tools/babel/babelrc.cjs.mjs
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const THIS_DIRNAME = import.meta.dirname;
+const THIS_FILENAME = fileURLToPath(import.meta.url);
+const THIS_DIRNAME = path.dirname(THIS_FILENAME);
 const pathResolve = path.resolve.bind(undefined, THIS_DIRNAME);
 
 export default {

--- a/packages/option-t/tools/babel/babelrc.d.cts.mjs
+++ b/packages/option-t/tools/babel/babelrc.d.cts.mjs
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const THIS_DIRNAME = import.meta.dirname;
+const THIS_FILENAME = fileURLToPath(import.meta.url);
+const THIS_DIRNAME = path.dirname(THIS_FILENAME);
 const pathResolve = path.resolve.bind(undefined, THIS_DIRNAME);
 
 export default {

--- a/packages/option-t/tools/extension_renamer.mjs
+++ b/packages/option-t/tools/extension_renamer.mjs
@@ -1,12 +1,12 @@
 import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-const THIS_FILE_NAME = import.meta.filename;
-
 function debug(input) {
-    console.log(`${THIS_FILE_NAME}: ${input}`);
+    const filename = fileURLToPath(import.meta.url);
+    console.log(`${filename}: ${input}`);
 }
 
 async function* getAllDescendantFiles(subrootDir) {

--- a/packages/option-t/tools/generate_import_path_list_markdown.mjs
+++ b/packages/option-t/tools/generate_import_path_list_markdown.mjs
@@ -1,11 +1,13 @@
 import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import { generateExposedPathSequence } from './public_api/mod.mjs';
 
-const THIS_DIR_NAME = import.meta.dirname;
+const THIS_FILE_NAME = fileURLToPath(import.meta.url);
+const THIS_DIR_NAME = path.dirname(THIS_FILE_NAME);
 
 const RELATIVE_PATH_TO_SRC_DIR = '../src';
 const RELATIVE_PATH_TO_SRC_DIR_IN_MONOREPO = '../packages/option-t/src';

--- a/packages/option-t/tools/package_json_rewriter/main.mjs
+++ b/packages/option-t/tools/package_json_rewriter/main.mjs
@@ -1,12 +1,14 @@
 import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import { loadJSON } from './json.mjs';
 import { addExportsFields } from './transformer/add_exports_field/main.mjs';
 
-const THIS_DIRNAME = import.meta.dirname;
+const THIS_FILENAME = fileURLToPath(import.meta.url);
+const THIS_DIRNAME = path.dirname(THIS_FILENAME);
 
 const BASE_DIR = THIS_DIRNAME;
 


### PR DESCRIPTION
Reverts option-t/option-t#1990

vscode 1.86 still uses Node.js 18.17.1. ESLint extensions would not work if we use them.