### PR TITLE
Add examples to import `option-t/<TypeName>/namespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,17 @@ If you're project cannot import by their path, please read [this guide](./docs/h
 
 #### Examples
 
-```js
-import { isNotNull } from 'option-t/Nullable';
+```ts
+// Import only functions or types which you would like to use.
+import { isNotNull, type Nullable } from 'option-t/Nullable';
 import { unwrapNullable } from 'option-t/Nullable/Nullable';
 import { createOk, isOk } from 'option-t/PlainResult';
+
+// You can use `<TypeName>.<operatorName>` style.
+import * as Nullable from 'option-t/Nullable/namespace';
+
+declare let numberOrNull: Nullable.Nullable<number>;
+const some = Nullable.unwrapOr(numberOrNull, -1);
 ```
 
 

--- a/docs/how_to_import.md
+++ b/docs/how_to_import.md
@@ -4,13 +4,21 @@
 
 ### Examples
 
-```js
-import { isNotNull } from 'option-t/Nullable';
-import { mapForNullable } from 'option-t/Nullable/map';
+```ts
+// Import only functions or types which you would like to use.
+import { isNotNull, type Nullable } from 'option-t/Nullable';
+import { unwrapNullable } from 'option-t/Nullable/Nullable';
 import { createOk, isOk } from 'option-t/PlainResult';
 
-// or
+// You can use `<TypeName>.<operatorName>` style.
+import * as Nullable from 'option-t/Nullable/namespace';
 
+declare let numberOrNull: Nullable.Nullable<number>;
+const some = Nullable.unwrapOr(numberOrNull, -1);
+```
+
+```js
+// for commonjs
 const { isNotNull } = require('option-t/Nullable');
 const { mapForNullable } = require('option-t/Nullable/map');
 const { createOk, isOk } = require('option-t/PlainResult');


### PR DESCRIPTION
We designed `option-t/<TypeName>/namespace` to allow to use  intellisense friendly (& some redundants) but we don't talk about it in anywhere of documents. Let's add the example for it.