### PR TITLE
Add more strict type restriction for type conversion APIs

### DIFF
--- a/packages/option-t/src/classic_option/compat.ts
+++ b/packages/option-t/src/classic_option/compat.ts
@@ -60,7 +60,7 @@ export function compatToNullableFromClassicOption<T>(
     }
 
     const inner = input.unwrap();
-    const value: T = expectNotNull(inner, ERR_MSG_CANNOT_CONVERT_TO_NULLABLE);
+    const value: NotNull<T> = expectNotNull(inner, ERR_MSG_CANNOT_CONVERT_TO_NULLABLE);
     return value;
 }
 
@@ -92,7 +92,7 @@ export function compatToUndefinableFromClassicOption<T>(
     }
 
     const inner = input.unwrap();
-    const value: T = expectNotUndefined(inner, ERR_MSG_CANNOT_CONVERT_TO_UNDEFINABLE);
+    const value: NotUndefined<T> = expectNotUndefined(inner, ERR_MSG_CANNOT_CONVERT_TO_UNDEFINABLE);
     return value;
 }
 

--- a/packages/option-t/src/maybe/map.ts
+++ b/packages/option-t/src/maybe/map.ts
@@ -23,7 +23,7 @@ export function mapForMaybe<T, U>(
         return input;
     }
 
-    const result: U = transformer(input);
+    const result: NotNullOrUndefined<U> = transformer(input);
     // XXX:
     // If `U` is `Maybe<SomeType>`, we think naturally the returned value of this function would be
     // the nested type `Maybe<Maybe<SomeType>>`. But this type means `(SomeType | null | undefined) | null | undefined`.

--- a/packages/option-t/src/maybe/map_async.ts
+++ b/packages/option-t/src/maybe/map_async.ts
@@ -24,7 +24,7 @@ export async function mapAsyncForMaybe<T, U>(
         return input;
     }
 
-    const result: U = await transformer(input);
+    const result: NotNullOrUndefined<U> = await transformer(input);
 
     // XXX:
     // If `U` is `Maybe<SomeType>`, we think naturally the returned value of this function would be

--- a/packages/option-t/src/maybe/map_or.ts
+++ b/packages/option-t/src/maybe/map_or.ts
@@ -21,7 +21,7 @@ export function mapOrForMaybe<T, U>(
     defaultValue: NotNullOrUndefined<U>,
     transformer: TransformFn<T, NotNullOrUndefined<U>>,
 ): NotNullOrUndefined<U> {
-    let result: U;
+    let result: NotNullOrUndefined<U>;
     let msg = '';
     if (input !== undefined && input !== null) {
         result = transformer(input);

--- a/packages/option-t/src/maybe/map_or_async.ts
+++ b/packages/option-t/src/maybe/map_or_async.ts
@@ -35,7 +35,7 @@ export async function mapOrAsyncForMaybe<T, U>(
         return nonNullDefault;
     }
 
-    const result: U = await transformer(input);
+    const result: NotNullOrUndefined<U> = await transformer(input);
     const checked: NotNullOrUndefined<U> = expectNotNullOrUndefined(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE,

--- a/packages/option-t/src/maybe/map_or_else.ts
+++ b/packages/option-t/src/maybe/map_or_else.ts
@@ -21,7 +21,7 @@ export function mapOrElseForMaybe<T, U>(
     recoverer: RecoveryFn<NotNullOrUndefined<U>>,
     transformer: TransformFn<T, NotNullOrUndefined<U>>,
 ): NotNullOrUndefined<U> {
-    let result: U;
+    let result: NotNullOrUndefined<U>;
     let msg = '';
     if (input !== undefined && input !== null) {
         result = transformer(input);

--- a/packages/option-t/src/maybe/map_or_else_async.ts
+++ b/packages/option-t/src/maybe/map_or_else_async.ts
@@ -27,7 +27,7 @@ export async function mapOrElseAsyncForMaybe<T, U>(
     recoverer: AsyncRecoveryFn<NotNullOrUndefined<U>>,
     transformer: AsyncTransformFn<T, NotNullOrUndefined<U>>,
 ): Promise<NotNullOrUndefined<U>> {
-    let result: U;
+    let result: NotNullOrUndefined<U>;
     let messageForExpect = '';
 
     if (isNotNullOrUndefined(input)) {

--- a/packages/option-t/src/maybe/to_nullable.ts
+++ b/packages/option-t/src/maybe/to_nullable.ts
@@ -1,11 +1,11 @@
-import type { Nullable } from '../nullable/nullable.js';
+import type { NotNull, Nullable } from '../nullable/nullable.js';
 import { type Maybe, isNullOrUndefined } from './maybe.js';
 
 /**
  *  Return `null` if _input_ is `null` or `undfined`.
  *  Otherwise, return `T` directly.
  */
-export function toNullableFromMaybe<T>(input: Maybe<T>): Nullable<T> {
+export function toNullableFromMaybe<T>(input: Maybe<NotNull<T>>): Nullable<T> {
     if (isNullOrUndefined(input)) {
         return null;
     }

--- a/packages/option-t/src/maybe/to_undefinable.ts
+++ b/packages/option-t/src/maybe/to_undefinable.ts
@@ -1,11 +1,11 @@
-import type { Undefinable } from '../undefinable/undefinable.js';
+import type { NotUndefined, Undefinable } from '../undefinable/undefinable.js';
 import { type Maybe, isNullOrUndefined } from './maybe.js';
 
 /**
  *  Return `undfined` if _input_ is `null` or `undfined`.
  *  Otherwise, return `T` directly.
  */
-export function toUndefinableFromMaybe<T>(input: Maybe<T>): Undefinable<T> {
+export function toUndefinableFromMaybe<T>(input: Maybe<NotUndefined<T>>): Undefinable<T> {
     if (isNullOrUndefined(input)) {
         return undefined;
     }

--- a/packages/option-t/src/maybe/unwrap_or_else.ts
+++ b/packages/option-t/src/maybe/unwrap_or_else.ts
@@ -22,7 +22,7 @@ export function unwrapOrElseForMaybe<T>(
         return input;
     }
 
-    const fallback: T = recoverer();
+    const fallback: NotNullOrUndefined<T> = recoverer();
     const passed = expectNotNullOrUndefined(
         fallback,
         ERR_MSG_RECOVERER_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE,

--- a/packages/option-t/src/maybe/unwrap_or_else_async.ts
+++ b/packages/option-t/src/maybe/unwrap_or_else_async.ts
@@ -23,7 +23,7 @@ export async function unwrapOrElseAsyncForMaybe<T>(
         return input;
     }
 
-    const fallback: T = await recoverer();
+    const fallback: NotNullOrUndefined<T> = await recoverer();
 
     const checked = expectNotNullOrUndefined(
         fallback,

--- a/packages/option-t/src/maybe/zip_with.ts
+++ b/packages/option-t/src/maybe/zip_with.ts
@@ -25,7 +25,7 @@ export function zipWithForMaybe<T, U, R>(
         return undefined;
     }
 
-    const result: R = transformer(self, other);
+    const result: NotNullOrUndefined<R> = transformer(self, other);
     const checked: NotNullOrUndefined<R> = expectNotNullOrUndefined(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE,

--- a/packages/option-t/src/maybe/zip_with_async.ts
+++ b/packages/option-t/src/maybe/zip_with_async.ts
@@ -25,7 +25,7 @@ export async function zipWithAsyncForMaybe<T, U, R>(
         return undefined;
     }
 
-    const result: R = await transformer(self, other);
+    const result: NotNullOrUndefined<R> = await transformer(self, other);
     const checked: NotNullOrUndefined<R> = expectNotNullOrUndefined(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE,

--- a/packages/option-t/src/nullable/map_or.ts
+++ b/packages/option-t/src/nullable/map_or.ts
@@ -21,7 +21,7 @@ export function mapOrForNullable<T, U>(
     defaultValue: NotNull<U>,
     transformer: TransformFn<T, NotNull<U>>,
 ): NotNull<U> {
-    let result: U;
+    let result: NotNull<U>;
     let msg = '';
     if (input !== null) {
         result = transformer(input);

--- a/packages/option-t/src/nullable/map_or_async.ts
+++ b/packages/option-t/src/nullable/map_or_async.ts
@@ -29,7 +29,7 @@ export async function mapOrAsyncForNullable<T, U>(
         return nonNullDefault;
     }
 
-    const result: U = await transformer(input);
+    const result: NotNull<U> = await transformer(input);
     const checked: NotNull<U> = expectNotNull(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE,

--- a/packages/option-t/src/nullable/map_or_else.ts
+++ b/packages/option-t/src/nullable/map_or_else.ts
@@ -21,7 +21,7 @@ export function mapOrElseForNullable<T, U>(
     recoverer: RecoveryFn<NotNull<U>>,
     transformer: TransformFn<T, NotNull<U>>,
 ): NotNull<U> {
-    let result: U;
+    let result: NotNull<U>;
     let msg = '';
     if (isNotNull(input)) {
         result = transformer(input);

--- a/packages/option-t/src/nullable/map_or_else_async.ts
+++ b/packages/option-t/src/nullable/map_or_else_async.ts
@@ -21,7 +21,7 @@ export async function mapOrElseAsyncForNullable<T, U>(
     recoverer: AsyncRecoveryFn<NotNull<U>>,
     transformer: AsyncTransformFn<T, NotNull<U>>,
 ): Promise<NotNull<U>> {
-    let result: U;
+    let result: NotNull<U>;
     let messageForExpect = '';
 
     if (isNotNull(input)) {

--- a/packages/option-t/src/nullable/to_undefinable.ts
+++ b/packages/option-t/src/nullable/to_undefinable.ts
@@ -1,11 +1,11 @@
-import type { Undefinable } from '../undefinable/undefinable.js';
+import type { NotUndefined, Undefinable } from '../undefinable/undefinable.js';
 import { type Nullable, isNull } from './nullable.js';
 
 /**
  *  Return `undefined` if _input_ is `null`.
  *  Otherwise, return `T` directly.
  */
-export function toUndefinableFromNullable<T>(input: Nullable<T>): Undefinable<T> {
+export function toUndefinableFromNullable<T>(input: Nullable<NotUndefined<T>>): Undefinable<T> {
     if (isNull(input)) {
         return undefined;
     }

--- a/packages/option-t/src/nullable/unwrap_or_else.ts
+++ b/packages/option-t/src/nullable/unwrap_or_else.ts
@@ -18,7 +18,7 @@ export function unwrapOrElseForNullable<T>(
         return input;
     }
 
-    const fallback: T = recoverer();
+    const fallback: NotNull<T> = recoverer();
     const passed: NotNull<T> = expectNotNull(
         fallback,
         ERR_MSG_RECOVERER_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE,

--- a/packages/option-t/src/nullable/zip_with.ts
+++ b/packages/option-t/src/nullable/zip_with.ts
@@ -19,7 +19,7 @@ export function zipWithForNullable<T, U, R>(
         return null;
     }
 
-    const result: R = transformer(self, other);
+    const result: NotNull<R> = transformer(self, other);
     const checked: NotNull<R> = expectNotNull(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE,

--- a/packages/option-t/src/nullable/zip_with_async.ts
+++ b/packages/option-t/src/nullable/zip_with_async.ts
@@ -19,7 +19,7 @@ export async function zipWithAsyncForNullable<T, U, R>(
         return null;
     }
 
-    const result: R = await transformer(self, other);
+    const result: NotNull<R> = await transformer(self, other);
     const checked: NotNull<R> = expectNotNull(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE,

--- a/packages/option-t/src/plain_option/to_nullable.ts
+++ b/packages/option-t/src/plain_option/to_nullable.ts
@@ -1,14 +1,12 @@
-import type { Nullable } from '../nullable/nullable.js';
-import { mapOrForOption } from './map_or.js';
+import type { NotNull, Nullable } from '../nullable/nullable.js';
 import type { Option } from './option.js';
+import { unwrapOrForOption } from './unwrap_or.js';
 
 /**
  *  Return `T` if _input_ is `Some(T)`.
  *  Otherwise, return `null`.
  */
-export function toNullableFromOption<T>(input: Option<T>): Nullable<T> {
-    const rv = mapOrForOption<T, Nullable<T>>(input, null, (inner: T) => {
-        return inner;
-    });
+export function toNullableFromOption<T>(input: Option<NotNull<T>>): Nullable<T> {
+    const rv = unwrapOrForOption<Nullable<T>>(input, null);
     return rv;
 }

--- a/packages/option-t/src/plain_option/to_undefinable.ts
+++ b/packages/option-t/src/plain_option/to_undefinable.ts
@@ -1,14 +1,12 @@
-import type { Undefinable } from '../undefinable/undefinable.js';
-import { mapOrForOption } from './map_or.js';
+import type { NotUndefined, Undefinable } from '../undefinable/undefinable.js';
 import type { Option } from './option.js';
+import { unwrapOrForOption } from './unwrap_or.js';
 
 /**
  *  Return `T` if _input_ is `Some(T)`.
  *  Otherwise, return `undefined`.
  */
-export function toUndefinableFromOption<T>(input: Option<T>): Undefinable<T> {
-    const rv = mapOrForOption<T, Undefinable<T>>(input, undefined, (inner) => {
-        return inner;
-    });
+export function toUndefinableFromOption<T>(input: Option<NotUndefined<T>>): Undefinable<T> {
+    const rv = unwrapOrForOption<Undefinable<T>>(input, undefined);
     return rv;
 }

--- a/packages/option-t/src/plain_result/to_nullable.ts
+++ b/packages/option-t/src/plain_result/to_nullable.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from '../nullable/nullable.js';
+import type { NotNull, Nullable } from '../nullable/nullable.js';
 import { unwrapErrOrForResult } from './internal/unwrap_err_or.js';
 import type { Result } from './result.js';
 import { unwrapOrForResult } from './unwrap_or.js';
@@ -7,7 +7,7 @@ import { unwrapOrForResult } from './unwrap_or.js';
  *  Unwrap `T` if _input_ is `Ok(T)`.
  *  Otherwise, return `null`.
  */
-export function toNullableFromOk<T>(input: Result<T, unknown>): Nullable<T> {
+export function toNullableFromOk<T>(input: Result<NotNull<T>, unknown>): Nullable<T> {
     const val: Nullable<T> = unwrapOrForResult<Nullable<T>>(input, null);
     return val;
 }
@@ -16,7 +16,7 @@ export function toNullableFromOk<T>(input: Result<T, unknown>): Nullable<T> {
  *  Unwrap `E` if _input_ is `Err(E)`.
  *  Otherwise, return `null`.
  */
-export function toNullableFromErr<E>(input: Result<unknown, E>): Nullable<E> {
+export function toNullableFromErr<E>(input: Result<unknown, NotNull<E>>): Nullable<E> {
     const err: Nullable<E> = unwrapErrOrForResult<Nullable<E>>(input, null);
     return err;
 }

--- a/packages/option-t/src/plain_result/to_undefinable.ts
+++ b/packages/option-t/src/plain_result/to_undefinable.ts
@@ -1,4 +1,4 @@
-import type { Undefinable } from '../undefinable/undefinable.js';
+import type { NotUndefined, Undefinable } from '../undefinable/undefinable.js';
 import { unwrapErrOrForResult } from './internal/unwrap_err_or.js';
 import type { Result } from './result.js';
 import { unwrapOrForResult } from './unwrap_or.js';
@@ -7,7 +7,7 @@ import { unwrapOrForResult } from './unwrap_or.js';
  *  Unwrap `T` if _input_ is `Ok(T)`.
  *  Otherwise, return `undefined`.
  */
-export function toUndefinableFromOk<T>(input: Result<T, unknown>): Undefinable<T> {
+export function toUndefinableFromOk<T>(input: Result<NotUndefined<T>, unknown>): Undefinable<T> {
     const val: Undefinable<T> = unwrapOrForResult<Undefinable<T>>(input, undefined);
     return val;
 }
@@ -16,7 +16,7 @@ export function toUndefinableFromOk<T>(input: Result<T, unknown>): Undefinable<T
  *  Unwrap `E` if _input_ is `Err(E)`.
  *  Otherwise, return `undefined`.
  */
-export function toUndefinableFromErr<E>(input: Result<unknown, E>): Undefinable<E> {
+export function toUndefinableFromErr<E>(input: Result<unknown, NotUndefined<E>>): Undefinable<E> {
     const err: Undefinable<E> = unwrapErrOrForResult<Undefinable<E>>(input, undefined);
     return err;
 }

--- a/packages/option-t/src/undefinable/map_async.ts
+++ b/packages/option-t/src/undefinable/map_async.ts
@@ -23,7 +23,7 @@ export async function mapAsyncForUndefinable<T, U>(
         return undefined;
     }
 
-    const result: U = await transformer(input);
+    const result: NotUndefined<U> = await transformer(input);
 
     // XXX:
     // If `U` is `Undefinable<SomeType>`, we think naturally the returned value of this function would be

--- a/packages/option-t/src/undefinable/map_or.ts
+++ b/packages/option-t/src/undefinable/map_or.ts
@@ -21,7 +21,7 @@ export function mapOrForUndefinable<T, U>(
     defaultValue: NotUndefined<U>,
     transformer: TransformFn<T, NotUndefined<U>>,
 ): NotUndefined<U> {
-    let result: U;
+    let result: NotUndefined<U>;
     let msg = '';
     if (input !== undefined) {
         result = transformer(input);

--- a/packages/option-t/src/undefinable/map_or_async.ts
+++ b/packages/option-t/src/undefinable/map_or_async.ts
@@ -35,7 +35,7 @@ export async function mapOrAsyncForUndefinable<T, U>(
         return nonNullDefault;
     }
 
-    const result: U = await transformer(input);
+    const result: NotUndefined<U> = await transformer(input);
 
     const checked: NotUndefined<U> = expectNotUndefined(
         result,

--- a/packages/option-t/src/undefinable/map_or_else.ts
+++ b/packages/option-t/src/undefinable/map_or_else.ts
@@ -21,7 +21,7 @@ export function mapOrElseForUndefinable<T, U>(
     recoverer: RecoveryFn<NotUndefined<U>>,
     transformer: TransformFn<T, NotUndefined<U>>,
 ): NotUndefined<U> {
-    let result: U;
+    let result: NotUndefined<U>;
     let msg = '';
     if (input !== undefined) {
         result = transformer(input);

--- a/packages/option-t/src/undefinable/map_or_else_async.ts
+++ b/packages/option-t/src/undefinable/map_or_else_async.ts
@@ -26,7 +26,7 @@ export async function mapOrElseAsyncForUndefinable<T, U>(
     recoverer: AsyncRecoveryFn<NotUndefined<U>>,
     transformer: AsyncTransformFn<T, NotUndefined<U>>,
 ): Promise<NotUndefined<U>> {
-    let result: U;
+    let result: NotUndefined<U>;
     let messageForExpect = '';
 
     if (isNotUndefined(input)) {

--- a/packages/option-t/src/undefinable/to_nullable.ts
+++ b/packages/option-t/src/undefinable/to_nullable.ts
@@ -1,11 +1,11 @@
-import type { Nullable } from '../nullable/nullable.js';
+import type { NotNull, Nullable } from '../nullable/nullable.js';
 import { isUndefined, type Undefinable } from './undefinable.js';
 
 /**
  *  Return `null` if _input_ is `undfined`.
  *  Otherwise, return `T` directly.
  */
-export function toNullableFromUndefinable<T>(input: Undefinable<T>): Nullable<T> {
+export function toNullableFromUndefinable<T>(input: Undefinable<NotNull<T>>): Nullable<T> {
     if (isUndefined(input)) {
         return null;
     }

--- a/packages/option-t/src/undefinable/unwrap_or_else.ts
+++ b/packages/option-t/src/undefinable/unwrap_or_else.ts
@@ -23,7 +23,7 @@ export function unwrapOrElseForUndefinable<T>(
         return input;
     }
 
-    const fallback: T = recoverer();
+    const fallback: NotUndefined<T> = recoverer();
     const passed = expectNotUndefined(
         fallback,
         ERR_MSG_RECOVERER_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE,

--- a/packages/option-t/src/undefinable/unwrap_or_else_async.ts
+++ b/packages/option-t/src/undefinable/unwrap_or_else_async.ts
@@ -24,7 +24,7 @@ export async function unwrapOrElseAsyncForUndefinable<T>(
         return input;
     }
 
-    const fallback: T = await recoverer();
+    const fallback: NotUndefined<T> = await recoverer();
     const checked: NotUndefined<T> = expectNotUndefined(
         fallback,
         ERR_MSG_RECOVERER_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE,

--- a/packages/option-t/src/undefinable/zip_with.ts
+++ b/packages/option-t/src/undefinable/zip_with.ts
@@ -24,7 +24,7 @@ export function zipWithForUndefinable<T, U, R>(
         return undefined;
     }
 
-    const result: R = transformer(self, other);
+    const result: NotUndefined<R> = transformer(self, other);
     const checked: NotUndefined<R> = expectNotUndefined(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE,

--- a/packages/option-t/src/undefinable/zip_with_async.ts
+++ b/packages/option-t/src/undefinable/zip_with_async.ts
@@ -24,7 +24,7 @@ export async function zipWithAsyncForUndefinable<T, U, R>(
         return undefined;
     }
 
-    const result: R = await transformer(self, other);
+    const result: NotUndefined<R> = await transformer(self, other);
     const checked: NotUndefined<R> = expectNotUndefined(
         result,
         ERR_MSG_TRANSFORMER_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE,


### PR DESCRIPTION
This makes `Nullable`/`Maybe`/`Undefinable` types more strict.

As the most simple case, the following case would not be a problem previously. But this is meaningless type conversion.
This change prevents the case by type checking error. 

```ts
declare const bar: Undefinable<null>; 
const foo = toNullableFromUndefinable(bar); // foo's type is always `null`.
```

As more concrete case, see the next example. This `bar` is `undefinable | number | null`. It's just `Maybe<number>` substantially. Thus we should use `toNullableFromMaybe` instead.

```ts
declare const bar: Undefinable<number | null>;
const foo = toNullableFromUndefinable(bar); // foo's type is `Nullable<number | null>`. It's wired.
```

This changeset detects such case too.


This make these operators' type signatures more precise:

- Undefinable
    - toNullableFromUndefinable
- PlainResult
    - toUndefinableFromOk
    - toUndefinableFromErr
    - toNullableFromOk
    - toNullableFromErr
- PlainOption
    - toUndefinableFromOption
    - toNullableFromOption
- Nullable
    - toUndefinableFromNullable
- Maybe
    - toUndefinableFromMaybe
    - toNullableFromMaybe