### PR TITLE
Add comments about why we don't expose operators to compose a data flow from each of root endpoints.

### DIFF
--- a/packages/option-t/src/maybe/index.ts
+++ b/packages/option-t/src/maybe/index.ts
@@ -7,12 +7,8 @@ export {
     type NotNullOrUndefined,
 } from './maybe.js';
 
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
-//export { andForMaybe } from './and.js';
 export { andThenForMaybe } from './and_then.js';
 export { andThenAsyncForMaybe } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectMaybe } from './inspect.js';
 export { mapForMaybe } from './map.js';
 export { mapAsyncForMaybe } from './map_async.js';
@@ -23,8 +19,6 @@ export { mapOrElseAsyncForMaybe } from './map_or_else_async.js';
 export { okOrForMaybe } from './ok_or.js';
 export { okOrElseForMaybe } from './ok_or_else.js';
 export { okOrElseAsyncForMaybe } from './ok_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
-// export { orForMaybe } from './or.js';
 export { orElseForMaybe } from './or_else.js';
 export { orElseAsyncForMaybe } from './or_else_async.js';
 export { toNullableFromMaybe } from './to_nullable.js';
@@ -33,7 +27,21 @@ export { toUndefinableFromMaybe } from './to_undefinable.js';
 export { unwrapOrForMaybe } from './unwrap_or.js';
 export { unwrapOrElseForMaybe } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForMaybe } from './unwrap_or_else_async.js';
-// TODO: #2095
-// TODO: #2096
-// TODO: #2098
-// TODO: #2097
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by this default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync

--- a/packages/option-t/src/maybe/namespace.ts
+++ b/packages/option-t/src/maybe/namespace.ts
@@ -11,13 +11,9 @@ export {
     expectNotNullOrUndefined,
     unwrapMaybe,
 } from './maybe.js';
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by
-// default set.
-// export { andForMaybe as and } from './and.js';
+
 export { andThenForMaybe as andThen } from './and_then.js';
 export { andThenAsyncForMaybe as andThenAsync } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectMaybe as inspect } from './inspect.js';
 export { mapForMaybe as map } from './map.js';
 export { mapAsyncForMaybe as mapAsync } from './map_async.js';
@@ -25,8 +21,6 @@ export { mapOrForMaybe as mapOr } from './map_or.js';
 export { mapOrAsyncForMaybe as mapOrAsync } from './map_or_async.js';
 export { mapOrElseForMaybe as mapOrElse } from './map_or_else.js';
 export { mapOrElseAsyncForMaybe as mapOrElseAsync } from './map_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by
-// default set. export { orForMaybe as or } from './or.js';
 export { okOrForMaybe as okOr } from './ok_or.js';
 export { okOrElseForMaybe as okOrElse } from './ok_or_else.js';
 export { okOrElseAsyncForMaybe as okOrElseAsync } from './ok_or_else_async.js';
@@ -41,7 +35,21 @@ export { toUndefinableFromMaybe as toUndefinable } from './to_undefinable.js';
 export { unwrapOrForMaybe as unwrapOr } from './unwrap_or.js';
 export { unwrapOrElseForMaybe as unwrapOrElse } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForMaybe as unwrapOrElseAsync } from './unwrap_or_else_async.js';
-// TODO: #2088
-// TODO: #2089
-// TODO: #2090
-// TODO: #2091
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by this default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync

--- a/packages/option-t/src/nullable/index.ts
+++ b/packages/option-t/src/nullable/index.ts
@@ -6,12 +6,9 @@ export {
     type NotNull,
     type Nullable,
 } from './nullable.js';
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
-//export { andForNullable } from './and.js';
+
 export { andThenForNullable } from './and_then.js';
 export { andThenAsyncForNullable } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectNullable } from './inspect.js';
 export { mapForNullable } from './map.js';
 export { mapAsyncForNullable } from './map_async.js';
@@ -22,8 +19,6 @@ export { mapOrElseAsyncForNullable } from './map_or_else_async.js';
 export { okOrForNullable } from './ok_or.js';
 export { okOrElseForNullable } from './ok_or_else.js';
 export { okOrElseAsyncForNullable } from './ok_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
-// export { orForNullable } from './or.js';
 export { orElseForNullable } from './or_else.js';
 export { orElseAsyncForNullable } from './or_else_async.js';
 export { toResultErrFromNullable, toResultOkFromNullable } from './to_plain_result.js';
@@ -31,7 +26,21 @@ export { toUndefinableFromNullable } from './to_undefinable.js';
 export { unwrapOrForNullable } from './unwrap_or.js';
 export { unwrapOrElseForNullable } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForNullable } from './unwrap_or_else_async.js';
-// TODO: #2084
-// TODO: #2085
-// TODO: #2087
-// TODO: #2086
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by this default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync

--- a/packages/option-t/src/nullable/namespace.ts
+++ b/packages/option-t/src/nullable/namespace.ts
@@ -12,12 +12,8 @@ export {
     type Nullable,
 } from './nullable.js';
 
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
-//export { andForNullable as and } from './and.js';
 export { andThenForNullable as andThen } from './and_then.js';
 export { andThenAsyncForNullable as andThenAsync } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectNullable as inspect } from './inspect.js';
 export { mapForNullable as map } from './map.js';
 export { mapAsyncForNullable as mapAsync } from './map_async.js';
@@ -28,8 +24,6 @@ export { mapOrElseAsyncForNullable as mapOrElseAsync } from './map_or_else_async
 export { okOrForNullable as okOr } from './ok_or.js';
 export { okOrElseForNullable as okOrElse } from './ok_or_else.js';
 export { okOrElseAsyncForNullable as okOrElseAsync } from './ok_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
-// export { orForNullable as or } from './or.js';
 export { orElseForNullable as orElse } from './or_else.js';
 export { orElseAsyncForNullable as orElseAsync } from './or_else_async.js';
 export {
@@ -40,7 +34,21 @@ export { toUndefinableFromNullable as toUndefinable } from './to_undefinable.js'
 export { unwrapOrForNullable as unwrapOr } from './unwrap_or.js';
 export { unwrapOrElseForNullable as unwrapOrElse } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForNullable as unwrapOrElseAsync } from './unwrap_or_else_async.js';
-// TODO: #2058
-// TODO: #2059
-// TODO: #2060
-// TODO: #2061
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync

--- a/packages/option-t/src/plain_option/index.ts
+++ b/packages/option-t/src/plain_option/index.ts
@@ -42,13 +42,8 @@ export {
     type Some,
 } from './option.js';
 
-// TODO: #2099
 export { andThenForOption } from './and_then.js';
 export { andThenAsyncForOption } from './and_then_async.js';
-// - We don't expose items from as_mut.js that is unsafe operation.
-// - We don't expose items from drop.js that is unsafe operation.
-// - We don't expose items from equal.js that is provided for exception case.
-//   We don't recommend to compare this result type's value.
 export { filterForOption } from './filter.js';
 export { flattenForOption } from './flatten.js';
 export { fromErrToOption, fromOkToOption } from './from_result.js';
@@ -61,7 +56,6 @@ export { mapOrElseForOption } from './map_or_else.js';
 export { mapOrElseAsyncForOption } from './map_or_else_async.js';
 export { okOrForPlainOption } from './ok_or.js';
 export { okOrElseForPlainOption } from './ok_or_else.js';
-// TODO: #2105
 export { orElseForOption } from './or_else.js';
 export { orElseAsyncForOption } from './or_else_async.js';
 export { toNullableFromOption } from './to_nullable.js';
@@ -70,4 +64,23 @@ export { transposeOptionToResult, transposeResultToOption } from './transpose.js
 export { unwrapOrForOption } from './unwrap_or.js';
 export { unwrapOrElseForOption } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForOption } from './unwrap_or_else_async.js';
-// TODO: #2108
+
+// XXX:
+//  We don't expose these itens that is unsafe operation.
+//
+//  - as_mut
+//  - drop
+//
+// XXX:
+//  _equals, we don't expose it by this due to that is provided for exception case
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - and
+//  - or
+//  - filter (This is exception because we shipped it for a long time)
+//  - xor

--- a/packages/option-t/src/plain_option/namespace.ts
+++ b/packages/option-t/src/plain_option/namespace.ts
@@ -22,13 +22,8 @@ export {
     type Some,
 } from './option.js';
 
-// TODO: #2049
 export { andThenForOption as andThen } from './and_then.js';
 export { andThenAsyncForOption as andThenAsync } from './and_then_async.js';
-// - We don't expose items from as_mut.js that is unsafe operation.
-// - We don't expose items from drop.js that is unsafe operation.
-// - We don't expose items from equal.js that is provided for exception case.
-//   We don't recommend to compare this result type's value.
 export { filterForOption as filter } from './filter.js';
 export { flattenForOption as flatten } from './flatten.js';
 export { fromErrToOption, fromOkToOption } from './from_result.js';
@@ -41,7 +36,6 @@ export { mapOrElseForOption as mapOrElse } from './map_or_else.js';
 export { mapOrElseAsyncForOption as mapOrElseAsync } from './map_or_else_async.js';
 export { okOrForPlainOption as okOr } from './ok_or.js';
 export { okOrElseForPlainOption as okOrElse } from './ok_or_else.js';
-// TODO: #2051
 export { orElseForOption as orElse } from './or_else.js';
 export { orElseAsyncForOption as orElseAsync } from './or_else_async.js';
 export { toNullableFromOption as toNullable } from './to_nullable.js';
@@ -53,4 +47,23 @@ export {
 export { unwrapOrForOption as unwrapOr } from './unwrap_or.js';
 export { unwrapOrElseForOption as unwrapOrElse } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForOption as unwrapOrElseAsync } from './unwrap_or_else_async.js';
-// TODO: #2052
+
+// XXX:
+//  We don't expose these itens that is unsafe operation.
+//
+//  - as_mut
+//  - drop
+//
+// XXX:
+//  _equals, we don't expose it by this due to that is provided for exception case
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - and
+//  - or
+//  - filter (This is exception because we shipped it for a long time)
+//  - xor

--- a/packages/option-t/src/plain_result/index.ts
+++ b/packages/option-t/src/plain_result/index.ts
@@ -37,13 +37,8 @@ export {
     type Result,
 } from './result.js';
 
-// TODO: #2117
 export { andThenForResult } from './and_then.js';
 export { andThenAsyncForResult } from './and_then_async.js';
-// - We don't expose items from as_mut.js that is unsafe operation.
-// - We don't expose items from drop.js that is unsafe operation.
-// - We don't expose items from equal.js that is provided for exception case.
-//   We don't recommend to compare this result type's value.
 export { flattenForResult } from './flatten.js';
 export { fromPromiseSettledResultToResult } from './from_promise_settled_result.js';
 export { inspectBothForResult, inspectErrForResult, inspectOkForResult } from './inspect.js';
@@ -55,7 +50,6 @@ export { mapOrForResult } from './map_or.js';
 export { mapOrAsyncForResult } from './map_or_async.js';
 export { mapOrElseForResult } from './map_or_else.js';
 export { mapOrElseAsyncForResult } from './map_or_else_async.js';
-// TODO: #2112
 export { orElseForResult } from './or_else.js';
 export { orElseAsyncForResult } from './or_else_async.js';
 export { toNullableFromErr, toNullableFromOk } from './to_nullable.js';
@@ -69,6 +63,31 @@ export {
 export { unwrapOrForResult } from './unwrap_or.js';
 export { unwrapOrElseForResult } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForResult } from './unwrap_or_else_async.js';
-// - From this module, we don't expose items from unwrap_or_throw_error.js.
-//   that is provided only for the case to bridge with exist codes.
-//   We recommend to handle result type in that style.
+
+// XXX:
+//  We don't expose these itens that is unsafe operation.
+//
+//  - as_mut
+//  - drop
+//
+// XXX:
+//  _equals, we don't expose it by this due to that is provided for exception case
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - and
+//  - or
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync
+//
+// XXX:
+//  _unwrap_or_throw_error_, we don't expose items from this for it.
+//  It is provided only for the case to bridge with exist codes.
+//  We recommend to handle result type in that style.

--- a/packages/option-t/src/plain_result/namespace.ts
+++ b/packages/option-t/src/plain_result/namespace.ts
@@ -17,13 +17,8 @@ export {
     type Result,
 } from './result.js';
 
-// TODO: #2063
 export { andThenForResult as andThen } from './and_then.js';
 export { andThenAsyncForResult as andThenAsync } from './and_then_async.js';
-// - We don't expose items from as_mut.js that is unsafe operation.
-// - We don't expose items from drop.js that is unsafe operation.
-// - We don't expose items from equal.js that is provided for exception case.
-//   We don't recommend to compare this result type's value.
 export { flattenForResult as flatten } from './flatten.js';
 export { fromPromiseSettledResultToResult as fromPromiseSettledResult } from './from_promise_settled_result.js';
 export {
@@ -39,7 +34,6 @@ export { mapOrForResult as mapOr } from './map_or.js';
 export { mapOrAsyncForResult as mapOrAsync } from './map_or_async.js';
 export { mapOrElseForResult as mapOrElse } from './map_or_else.js';
 export { mapOrElseAsyncForResult as mapOrElseAsync } from './map_or_else_async.js';
-// TODO: #2067
 export { orElseForResult as orElse } from './or_else.js';
 export { orElseAsyncForResult as orElseAsync } from './or_else_async.js';
 export { toNullableFromErr, toNullableFromOk } from './to_nullable.js';
@@ -59,6 +53,31 @@ export {
 export { unwrapOrForResult as unwrapOr } from './unwrap_or.js';
 export { unwrapOrElseForResult as unwrapOrElse } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForResult as unwrapOrElseAsync } from './unwrap_or_else_async.js';
-// - From this module, we don't expose items from unwrap_or_throw_error.js.
-//   that is provided only for the case to bridge with exist codes.
-//   We recommend to handle result type in that style.
+
+// XXX:
+//  We don't expose these itens that is unsafe operation.
+//
+//  - as_mut
+//  - drop
+//
+// XXX:
+//  _equals, we don't expose it by this due to that is provided for exception case
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - and
+//  - or
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync
+//
+// XXX:
+//  _unwrap_or_throw_error_, we don't expose items from this for it.
+//  It is provided only for the case to bridge with exist codes.
+//  We recommend to handle result type in that style.

--- a/packages/option-t/src/undefinable/index.ts
+++ b/packages/option-t/src/undefinable/index.ts
@@ -6,12 +6,9 @@ export {
     type NotUndefined,
     type Undefinable,
 } from './undefinable.js';
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
-//export { andForUndefinable } from './and.js';
+
 export { andThenForUndefinable } from './and_then.js';
 export { andThenAsyncForUndefinable } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectUndefinable } from './inspect.js';
 export { mapForUndefinable } from './map.js';
 export { mapAsyncForUndefinable } from './map_async.js';
@@ -22,8 +19,6 @@ export { mapOrElseAsyncForUndefinable } from './map_or_else_async.js';
 export { okOrForUndefinable } from './ok_or.js';
 export { okOrElseForUndefinable } from './ok_or_else.js';
 export { okOrElseAsyncForUndefinable } from './ok_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
-// export { orForUndefinable } from './or.js';
 export { orElseForUndefinable } from './or_else.js';
 export { orElseAsyncForUndefinable } from './or_else_async.js';
 export { toNullableFromUndefinable } from './to_nullable.js';
@@ -31,7 +26,21 @@ export { toResultErrFromUndefinable, toResultOkFromUndefinable } from './to_plai
 export { unwrapOrForUndefinable } from './unwrap_or.js';
 export { unwrapOrElseForUndefinable } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForUndefinable } from './unwrap_or_else_async.js';
-// TODO: #2071
-// TODO: #2072
-// TODO: #2073
-// TODO: #2074
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by this default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync

--- a/packages/option-t/src/undefinable/namespace.ts
+++ b/packages/option-t/src/undefinable/namespace.ts
@@ -11,12 +11,9 @@ export {
     expectNotUndefined,
     unwrapUndefinable,
 } from './undefinable.js';
-// XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
-//export { andForUndefinable as and } from './and.js';
+
 export { andThenForUndefinable as andThen } from './and_then.js';
 export { andThenAsyncForUndefinable as andThenAsync } from './and_then_async.js';
-// XXX:
-//  We exposed filter once from here during v41 but it was too early decision.
 export { inspectUndefinable as inspect } from './inspect.js';
 export { mapForUndefinable as map } from './map.js';
 export { mapAsyncForUndefinable as mapAsync } from './map_async.js';
@@ -24,8 +21,6 @@ export { mapOrForUndefinable as mapOr } from './map_or.js';
 export { mapOrAsyncForUndefinable as mapOrAsync } from './map_or_async.js';
 export { mapOrElseForUndefinable as mapOrElse } from './map_or_else.js';
 export { mapOrElseAsyncForUndefinable as mapOrElseAsync } from './map_or_else_async.js';
-// XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
-// export { orForUndefinable as or } from './or.js';
 export { okOrForUndefinable as okOr } from './ok_or.js';
 export { okOrElseForUndefinable as okOrElse } from './ok_or_else.js';
 export { okOrElseAsyncForUndefinable as okOrElseAsync } from './ok_or_else_async.js';
@@ -39,7 +34,21 @@ export {
 export { unwrapOrForUndefinable as unwrapOr } from './unwrap_or.js';
 export { unwrapOrElseForUndefinable as unwrapOrElse } from './unwrap_or_else.js';
 export { unwrapOrElseAsyncForUndefinable as unwrapOrElseAsync } from './unwrap_or_else_async.js';
-// TODO: #2054
-// TODO: #2055
-// TODO: #2056
-// TODO: #2057
+
+// XXX:
+//  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.
+//
+// XXX:
+//  _or_ operation is equivalent of `a || b` so we don't ship it by this default set.
+//
+// XXX:
+//  To keep a simple API set,
+//  we don't expose APIs from here that takes multiple values to compose a data flow pipeline.
+//  We may reconsider it if pipeline operator syntax proposal is advanced to the standard.
+//  But please import them directly from their path at this moment.
+//
+//  - filter
+//  - xor
+//  - zip
+//  - zipWith
+//  - zipWithAsync


### PR DESCRIPTION
To keep a simple API set, we don't expose APIs from there that takes multiple values to compose a data flow pipeline. We may reconsider it if pipeline operator syntax proposal is advanced to the standard.

- Fix #2049
- Fix #2051
- Fix #2051
- Fix #2052
- Fix #2054
- Fix #2055 
- Fix #2056
- Fix #2057
- Fix #2058
- Fix #2059
- Fix #2060
- Fix #2061
- Fix #2063
- Fix #2067
- Fix #2071
- Fix #2072
- Fix #2073
- Fix #2074
- Fix #2084
- Fix #2085
- Fix #2086
- Fix #2087
- Fix #2088
- Fix #2089
- Fix #2090
- Fix #2091
- Fix #2095
- Fix #2096
- Fix #2097
- Fix #2098
- Fix #2099
- Fix #2105
- Fix #2108
- Fix #2112
- Fix #2117