### PR TITLE
Add why we don't export self type as `Type` from `<TypeName>/namespace`

### DIFF
--- a/packages/option-t/src/maybe/namespace.ts
+++ b/packages/option-t/src/maybe/namespace.ts
@@ -6,6 +6,11 @@
 export {
     type NotNullOrUndefined,
     type Maybe,
+    // XXX:
+    //  If we export self type as `Type`, vscode's IntelliSense (tsserver) will try to import `Type`
+    //  or import it directly from this path when you input `T` of `Type` or some case you want to import `Type`.
+    //  Because this module path is exposed to userland via `exports` field.
+    //  It's less ergonomic so we don't export here.
     isNotNullOrUndefined,
     isNullOrUndefined,
     expectNotNullOrUndefined,

--- a/packages/option-t/src/nullable/namespace.ts
+++ b/packages/option-t/src/nullable/namespace.ts
@@ -6,6 +6,11 @@
 export {
     type NotNull,
     type Nullable,
+    // XXX:
+    //  If we export self type as `Type`, vscode's IntelliSense (tsserver) will try to import `Type`
+    //  or import it directly from this path when you input `T` of `Type` or some case you want to import `Type`.
+    //  Because this module path is exposed to userland via `exports` field.
+    //  It's less ergonomic so we don't export here.
     expectNotNull,
     isNotNull,
     isNull,

--- a/packages/option-t/src/plain_option/namespace.ts
+++ b/packages/option-t/src/plain_option/namespace.ts
@@ -20,6 +20,11 @@ export {
     type None,
     type Option,
     type Some,
+    // XXX:
+    //  If we export self type as `Type`, vscode's IntelliSense (tsserver) will try to import `Type`
+    //  or import it directly from this path when you input `T` of `Type` or some case you want to import `Type`.
+    //  Because this module path is exposed to userland via `exports` field.
+    //  It's less ergonomic so we don't export here.
 } from './option.js';
 
 export { andThenForOption as andThen } from './and_then.js';

--- a/packages/option-t/src/plain_result/namespace.ts
+++ b/packages/option-t/src/plain_result/namespace.ts
@@ -7,6 +7,11 @@ export {
     type Err,
     type Ok,
     type Result,
+    // XXX:
+    //  If we export self type as `Type`, vscode's IntelliSense (tsserver) will try to import `Type`
+    //  or import it directly from this path when you input `T` of `Type` or some case you want to import `Type`.
+    //  Because this module path is exposed to userland via `exports` field.
+    //  It's less ergonomic so we don't export here.
     createErr,
     createOk,
     expectErr,

--- a/packages/option-t/src/undefinable/namespace.ts
+++ b/packages/option-t/src/undefinable/namespace.ts
@@ -6,6 +6,11 @@
 export {
     type NotUndefined,
     type Undefinable,
+    // XXX:
+    //  If we export self type as `Type`, vscode's IntelliSense (tsserver) will try to import `Type`
+    //  or import it directly from this path when you input `T` of `Type` or some case you want to import `Type`.
+    //  Because this module path is exposed to userland via `exports` field.
+    //  It's less ergonomic so we don't export here.
     isNotUndefined,
     isUndefined,
     expectNotUndefined,


### PR DESCRIPTION
This follows up https://github.com/option-t/option-t/issues/2173