### PR TITLE
Use ES2020 as our ESM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ We target to run in following environments.
     - [ECMA262 2017 edition](https://262.ecma-international.org/8.0/).
     - TypeScript's latest version.
 - Module system
-    - ES Module ([ES2015](https://262.ecma-international.org/6.0/) level).
+    - ES Module ([ES2020](https://262.ecma-international.org/11.0/) level).
     - CommonJS
     - A runtime environment or module bundler must support Node.js' [package.json's `exports` field](https://nodejs.org/api/packages.html#package-entry-points) (Newer is better).
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "devDependencies": {
         "@babel/core": "^7.24.5",
         "@babel/plugin-syntax-typescript": "^7.24.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.24.1",
         "@babel/plugin-transform-modules-commonjs": "^7.24.1",
         "@eslint/js": "^9.2.0",
         "@reflink/reflink": "^0.1.16",

--- a/packages/option-t/src/maybe/namespace.ts
+++ b/packages/option-t/src/maybe/namespace.ts
@@ -1,5 +1,1 @@
-// We still use ES2015 as a module format.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as Maybe from './internal/intermediate_namespace.js';
-
-export { Maybe };
+export * as Maybe from './internal/intermediate_namespace.js';

--- a/packages/option-t/src/nullable/namespace.ts
+++ b/packages/option-t/src/nullable/namespace.ts
@@ -1,5 +1,1 @@
-// We still use ES2015 as a module format.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as Nullable from './internal/intermediate_namespace.js';
-
-export { Nullable };
+export * as Nullable from './internal/intermediate_namespace.js';

--- a/packages/option-t/src/plain_option/namespace.ts
+++ b/packages/option-t/src/plain_option/namespace.ts
@@ -4,8 +4,4 @@
  *  Consider to use `Nullable<T>`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value.
  *  In JavaScript, they satisfy almost use cases. Probably, you might not have to use this type.
  */
-// We still use ES2015 as a module format.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as Option from './internal/intermediate_namespace.js';
-
-export { Option };
+export * as Option from './internal/intermediate_namespace.js';

--- a/packages/option-t/src/plain_result/namespace.ts
+++ b/packages/option-t/src/plain_result/namespace.ts
@@ -1,5 +1,1 @@
-// We still use ES2015 as a module format.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as Result from './internal/intermediate_namespace.js';
-
-export { Result };
+export * as Result from './internal/intermediate_namespace.js';

--- a/packages/option-t/src/undefinable/namespace.ts
+++ b/packages/option-t/src/undefinable/namespace.ts
@@ -1,5 +1,1 @@
-// We still use ES2015 as a module format.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as Undefinable from './internal/intermediate_namespace.js';
-
-export { Undefinable };
+export * as Undefinable from './internal/intermediate_namespace.js';

--- a/packages/option-t/tools/babel/babelrc.cjs.mjs
+++ b/packages/option-t/tools/babel/babelrc.cjs.mjs
@@ -20,5 +20,6 @@ export default {
                 strict: true,
             },
         ],
+        ['@babel/plugin-transform-export-namespace-from', {}],
     ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.24.1
         version: 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-export-namespace-from':
+        specifier: ^7.24.1
+        version: 7.24.1(@babel/core@7.24.5)
       '@babel/plugin-transform-modules-commonjs':
         specifier: ^7.24.1
         version: 7.24.1(@babel/core@7.24.5)
@@ -180,8 +183,19 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-syntax-export-namespace-from@7.8.3':
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-typescript@7.24.1':
     resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-export-namespace-from@7.24.1':
+    resolution: {integrity: sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2033,10 +2047,21 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.5
 
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
+
   '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
+
+  '@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
 
   '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.5)':
     dependencies:


### PR DESCRIPTION
We expect recent bundlers supports it for a long time ago. It's the time to shift now.