### PR TITLE
Remove redundant CI matrix

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -106,7 +106,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 20
                     - 22
         steps:
             - uses: actions/checkout@v4
@@ -124,7 +123,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 20
                     - 22
         steps:
             - uses: actions/checkout@v4
@@ -142,7 +140,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 20
                     - 22
 
         steps:


### PR DESCRIPTION
We moved all import behavior tests to unittest.
We don't have to run others with multiple Node.js