### PR TITLE
Add testcases for dealing with cross-relam `Error` instance to `tryCatchIntoWithEnsureError` & `unwrapOrThrowWithEnsureError`

### DIFF
--- a/packages/api_tests/__tests__/cross_realm_error_helper.mjs
+++ b/packages/api_tests/__tests__/cross_realm_error_helper.mjs
@@ -1,0 +1,16 @@
+import * as vm from 'node:vm';
+
+/**
+ *  @param  {import('ava').Assertions}    t
+ */
+export function getCrossRealmErrorConstructor(t) {
+    t.assert(t, `should pass ava's Assertions`);
+
+    const vmContext = vm.createContext();
+    const crossRealmErrorCtor = vm.runInNewContext('globalThis.Error', vmContext);
+    t.assert(
+        typeof crossRealmErrorCtor === 'function',
+        'could not get cross-realm `Error` consturctor',
+    );
+    return crossRealmErrorCtor;
+}

--- a/packages/api_tests/__tests__/plain_result/try_catch_async/try_catch_with_ensure_error_async/producer_is_normal_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/try_catch_async/try_catch_with_ensure_error_async/producer_is_normal_fn.test.mjs
@@ -7,6 +7,7 @@ import {
     unwrapErr as unwrapErrFromResult,
 } from 'option-t/plain_result/result';
 import { tryCatchIntoResultWithEnsureErrorAsync } from 'option-t/plain_result/try_catch_async';
+import { getCrossRealmErrorConstructor } from '../../../cross_realm_error_helper.mjs';
 
 test('output=Ok(T): producer is normal fn', async (t) => {
     t.plan(4);
@@ -72,7 +73,7 @@ test('if producer is normal function and reject a Promise with not-Error-instanc
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
+            message: "The thrown value is not an instance of the current relam's `Error`.",
         },
     );
 
@@ -94,7 +95,36 @@ test('if producer is normal function and throw a not-Error-instance value before
         },
         {
             instanceOf: TypeError,
-            message: `The thrown value is not an \`Error\` instance.`,
+            message: "The thrown value is not an instance of the current relam's `Error`.",
+        },
+    );
+
+    t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
+});
+
+test('if producer is normal function and throw a instance value from cross-realm `Error` constructor before return any `Promise`', async (t) => {
+    t.plan(6);
+    const CurrentRealmErrorCtor = globalThis.Error;
+
+    // arrange
+    const CrossRealmErrorCtor = getCrossRealmErrorConstructor(t);
+    const THROWN_EXPECTED = new CrossRealmErrorCtor(Math.random());
+    t.false(
+        THROWN_EXPECTED instanceof CurrentRealmErrorCtor,
+        `the thrown error should not be the instance of current relam's Error consturctor`,
+    );
+
+    const actual = await t.throwsAsync(
+        async () => {
+            await tryCatchIntoResultWithEnsureErrorAsync(() => {
+                t.pass('producer is called');
+                throw THROWN_EXPECTED;
+            });
+            t.fail('unreachable here');
+        },
+        {
+            instanceOf: TypeError,
+            message: "The thrown value is not an instance of the current relam's `Error`.",
         },
     );
 

--- a/packages/api_tests/__tests__/plain_result/unwrap_or_throw/throw_error_with_assert.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unwrap_or_throw/throw_error_with_assert.test.mjs
@@ -3,6 +3,7 @@ import test from 'ava';
 
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { unwrapOrThrowWithEnsureErrorForResult } from 'option-t/plain_result/unwrap_or_throw_error';
+import { getCrossRealmErrorConstructor } from '../../cross_realm_error_helper.mjs';
 
 test('input is Ok(T)', (t) => {
     const VALUE_T = Math.random();
@@ -41,7 +42,33 @@ test('input is Err, but the contained value is not Error', (t) => {
         },
         {
             instanceOf: TypeError,
-            message: `The contained E should be \`Error\` instance.`,
+            message: "The contained E should be an instance of the current relam's `Error`.",
+        },
+    );
+
+    t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
+});
+
+test('input is Err, but the contained value is not an `Error` instance of current realm', (t) => {
+    t.plan(5);
+    const CurrentRealmErrorCtor = globalThis.Error;
+
+    // arrange
+    const CrossRealmErrorCtor = getCrossRealmErrorConstructor(t);
+    const ERROR_E = new CrossRealmErrorCtor(webcrypto.randomUUID());
+    t.false(
+        ERROR_E instanceof CurrentRealmErrorCtor,
+        `the thrown error should not be the instance of current relam's Error consturctor`,
+    );
+
+    const input = createErr(ERROR_E);
+    const thrown = t.throws(
+        () => {
+            unwrapOrThrowWithEnsureErrorForResult(input);
+        },
+        {
+            instanceOf: TypeError,
+            message: "The contained E should be an instance of the current relam's `Error`.",
         },
     );
 

--- a/packages/option-t/src/internal/error_message.ts
+++ b/packages/option-t/src/internal/error_message.ts
@@ -10,13 +10,13 @@ export const ERR_MSG_CALLED_WITH = 'called with ';
 export const ERR_MSG_DEFAULT_VALUE_MUST_NOT_BE = DEFAULT_VALUE_NAME + ' must not be ';
 export const ERR_MSG_RECOVERER_MUST_NOT_RETURN = RECOVERY_FUNCTION_NAME + ERR_MSG_MUST_NOT_RETURN;
 
-const MSG_BUILTIN_ERROR_INSTANCE = '`Error` instance.';
+const MSG_BUILTIN_ERROR_INSTANCE_OF_CURRENT_REALM = "an instance of the current relam's `Error`.";
 
 export const ERR_MSG_THROWN_VALUE_IS_NOT_BUILTIN_ERROR_INSTANCE =
-    'The thrown value is not an ' + MSG_BUILTIN_ERROR_INSTANCE;
+    'The thrown value is not ' + MSG_BUILTIN_ERROR_INSTANCE_OF_CURRENT_REALM;
 
 export const ERR_MSG_CONTAINED_TYPE_E_SHOULD_BE_BUILTIN_ERROR_INSTANCE =
-    'The contained E should be ' + MSG_BUILTIN_ERROR_INSTANCE;
+    'The contained E should be ' + MSG_BUILTIN_ERROR_INSTANCE_OF_CURRENT_REALM;
 
 export const ERR_MSG_INPUT_IS_FROZEN_NOT_CAST_TO_MUTABLE =
     'input is frozen, cannot cast to mutable';

--- a/packages/option-t/src/plain_result/try_catch.ts
+++ b/packages/option-t/src/plain_result/try_catch.ts
@@ -23,8 +23,15 @@ export function tryCatchIntoResult<T>(producer: ProducerFn<T>): Result<T, unknow
 
 /**
  *  - This function converts the returend value from _producer_ into `Ok(TValue)`.
- *  - If _producer_ throw an `Error` instance, this returns it with wrapping `Err(Error)`.
- *  - Otherwise, If _producer_ throw a not `Error` instance, then this throw `TypeError`.
+ *  - If _producer_ throw an `Error` instance of **current [relam][realm]**,
+ *    this returns it with wrapping `Err(Error)`.
+ *
+ *  @throws {TypeError}
+ *      This throws it if _producer_ throw the value that is not an instance of `Error` constructor of **current [relam][realm]**.
+ *
+ *  [realm]: https://262.ecma-international.org/14.0/#realm
+ *
+ * -----
  *
  *  NOTE:
  *  1. An user should narrow the scope of _producer_ to make it predictable that is in `Err(E)`.

--- a/packages/option-t/src/plain_result/try_catch_async.ts
+++ b/packages/option-t/src/plain_result/try_catch_async.ts
@@ -28,8 +28,15 @@ export async function tryCatchIntoResultAsync<T>(
 
 /**
  *  - This function converts the returend value from _producer_ into `Ok(TValue)`.
- *  - If _producer_ throw an `Error` instance, this returns it with wrapping `Err(Error)`.
- *  - Otherwise, If _producer_ throw a not `Error` instance, then this throw `TypeError`.
+ *  - If _producer_ throw an `Error` instance of **current [relam][realm]**,
+ *    this returns it with wrapping `Err(Error)`.
+ *
+ *  @throws {TypeError}
+ *      This throws it if _producer_ throw the value that is not an instance of `Error` constructor of **current [relam][realm]**.
+ *
+ *  [realm]: https://262.ecma-international.org/14.0/#realm
+ *
+ * -----
  *
  *  NOTE:
  *  1. An user should narrow the scope of _producer_ to make it predictable that is in `Err(E)`.

--- a/packages/option-t/src/plain_result/unwrap_or_throw_error.ts
+++ b/packages/option-t/src/plain_result/unwrap_or_throw_error.ts
@@ -31,8 +31,10 @@ import { type Result, isOk, unwrapOk, unwrapErr } from './result.js';
  *      This throws an inner value wrapped by Err(Error)`.
  *
  *  @throws {TypeError}
- *      If `Err` conatins a non `Error` instance value at the running time,
+ *      If `Err` conatins the value that is not an instance of `Error` constructor of **current [relam][realm]**,
  *      this throws an `TypeError` with setting the original value to `.cause`.
+ *
+ *  [realm]: https://262.ecma-international.org/14.0/#realm
  */
 export function unwrapOrThrowWithEnsureErrorForResult<T>(input: Result<T, Error>): T {
     if (isOk(input)) {


### PR DESCRIPTION
By the current design, these APIs are not works expectedly since we rely on `value instanceof Error` heavily in their internals if they deal with cross-[realm](https://tc39.es/ecma262/2024/multipage/executable-code-and-execution-contexts.html#realm) `Error` instance (e.g. `node:vm`, iframe, mis-implementation).

- `tryCatchIntoResultWithEnsureError()`
- `tryCatchIntoResultWithEnsureErrorAsync()`
- `unwrapOrThrowWithEnsureErrorForResult()`

For a long term, we can expect [Error.isError](https://github.com/tc39/proposal-is-error) should be a part of ECMA262 but it has a long way to go...

## Related Issues

- https://github.com/option-t/option-t/issues/2286