### PR TITLE
Mark `plain_result/unwrap_or_throw_error` & `plain_result/unwrap_or_throw_unknown` as deprecated in docs/public_api_list.md

### DIFF
--- a/docs/public_api_list.md
+++ b/docs/public_api_list.md
@@ -145,8 +145,8 @@
 - [option-t/plain_result/unwrap_or_else](../packages/option-t/src/plain_result/unwrap_or_else.ts)
 - [option-t/plain_result/unwrap_or_else_async](../packages/option-t/src/plain_result/unwrap_or_else_async.ts)
 - [option-t/plain_result/unwrap_or_throw](../packages/option-t/src/plain_result/unwrap_or_throw.ts)
-- [option-t/plain_result/unwrap_or_throw_error](../packages/option-t/src/plain_result/unwrap_or_throw_error.ts)
-- [option-t/plain_result/unwrap_or_throw_unknown](../packages/option-t/src/plain_result/unwrap_or_throw_unknown.ts)
+- [option-t/plain_result/unwrap_or_throw_error](../packages/option-t/src/plain_result/unwrap_or_throw_error.ts) (__deprecated__. Use `option-t/plain_result/unwrap_or_throw` instead.)
+- [option-t/plain_result/unwrap_or_throw_unknown](../packages/option-t/src/plain_result/unwrap_or_throw_unknown.ts) (__deprecated__. Use `option-t/plain_result/unwrap_or_throw` instead.)
 
 
 ## Undefinable

--- a/packages/option-t/tools/public_api/table.mjs
+++ b/packages/option-t/tools/public_api/table.mjs
@@ -4,6 +4,7 @@ import {
     pathRedirectionForRoot,
     pathRedirectionTo,
     pathRedirectionToAsExperimental,
+    pathRedirectionMarkedAsDeprecated,
 } from './api_path_descriptor.mjs';
 
 const MAYBE_DIR = 'maybe';
@@ -159,11 +160,13 @@ export const apiTable = Object.freeze({
         `${PLAIN_RESULT_DIR}/unwrap_or_else_async`,
     ),
     'plain_result/unwrap_or_throw': pathRedirectionTo(`${PLAIN_RESULT_DIR}/unwrap_or_throw`),
-    'plain_result/unwrap_or_throw_error': pathRedirectionTo(
+    'plain_result/unwrap_or_throw_error': pathRedirectionMarkedAsDeprecated(
         `${PLAIN_RESULT_DIR}/unwrap_or_throw_error`,
+        'Use `option-t/plain_result/unwrap_or_throw` instead.',
     ),
-    'plain_result/unwrap_or_throw_unknown': pathRedirectionTo(
+    'plain_result/unwrap_or_throw_unknown': pathRedirectionMarkedAsDeprecated(
         `${PLAIN_RESULT_DIR}/unwrap_or_throw_unknown`,
+        'Use `option-t/plain_result/unwrap_or_throw` instead.',
     ),
 
     'undefinable': pathRedirectionTo(`${UNDEFINABLE_DIR}/index`),


### PR DESCRIPTION
This follows up https://github.com/option-t/option-t/pull/2280