### PR TITLE
Remove `eslint.experimental.useFlatConfig setting`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-    // With dbaeumer.vscode-eslint v2.4.0, we need to enable this option explicitly.
-    "eslint.experimental.useFlatConfig": true,
     "eslint.validate": [
         "javascript",
         "javascriptreact",


### PR DESCRIPTION
That is deprecated since vscode-eslint 3.0.5 or later:

> There is a new `eslint.useFlatConfig`` setting which is honored by ESLint version 8.57.0 and above.
> If one of those versions is used, the extension adheres to the ESLint Flat config rollout plan.
> The setting has the same meaning as the environment variable `ESLINT_USE_FLAT_CONFIG`.
https://github.com/microsoft/vscode-eslint/tree/4b202340da986fec4f926e72312508e20b2140f0