### PR TITLE
Use public API as possible for testing for plain result

### DIFF
--- a/packages/api_tests/__tests__/plain_option/transpose/to_plain_option.test.mjs
+++ b/packages/api_tests/__tests__/plain_option/transpose/to_plain_option.test.mjs
@@ -2,7 +2,14 @@ import test from 'ava';
 
 import { createSome, createNone, isSome, isNone } from 'option-t/plain_option/option';
 import { transposeResultToOption } from 'option-t/plain_option/transpose';
-import { createOk, createErr, isOk, isErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 test('input is Ok<Some<T>>, the result should be Some(Ok(v))', (t) => {
     const val = Symbol('val');
@@ -14,7 +21,7 @@ test('input is Ok<Some<T>>, the result should be Some(Ok(v))', (t) => {
 
     t.true(isSome(actual), 'the outer should Some<Ok<T>>');
     t.true(isOk(actualInner), 'the inner should Ok<T>');
-    t.is(actualInner.val, val, "the inner's inner should T");
+    t.is(unwrapOk(actualInner), val, "the inner's inner should T");
     t.not(actual, input, 'the outer should be different from the input');
     t.not(actual, inner, "the outer should be different from the input's inner");
     t.not(actualInner, input, 'the inner should be different from the input');
@@ -39,6 +46,6 @@ test('input is Err<E>, the result should be Some(Err(e))', (t) => {
 
     t.true(isSome(actual), 'the outer should Some<Err<E>>');
     t.true(isErr(actualInner), 'the inner should Err<E>');
-    t.is(actualInner.err, inner, "the inner's inner should E");
+    t.is(unwrapErr(actualInner), inner, "the inner's inner should E");
     t.not(actualInner, input, 'the inner should be different from the input');
 });

--- a/packages/api_tests/__tests__/plain_option/transpose/to_result.test.mjs
+++ b/packages/api_tests/__tests__/plain_option/transpose/to_result.test.mjs
@@ -1,8 +1,8 @@
 import test from 'ava';
 
-import { createSome, createNone, isSome, isNone } from 'option-t/plain_option/option';
+import { createSome, createNone, isSome, isNone, unwrapSome } from 'option-t/plain_option/option';
 import { transposeOptionToResult } from 'option-t/plain_option/transpose';
-import { createOk, createErr, isOk, isErr } from 'option-t/plain_result/result';
+import { createOk, createErr, isOk, isErr, unwrapOk } from 'option-t/plain_result/result';
 
 test('input is Some<Ok<T>>, the result should be Ok(Some(x))', (t) => {
     const val = Symbol('val');
@@ -10,11 +10,11 @@ test('input is Some<Ok<T>>, the result should be Ok(Some(x))', (t) => {
     const input = createSome(inner);
     const actual = transposeOptionToResult(input);
 
-    const actualInner = actual.val;
+    const actualInner = unwrapOk(actual);
 
     t.true(isOk(actual), 'the outer should be Ok<Some<T>>');
     t.true(isSome(actualInner), 'the inner should be Some<T>');
-    t.is(actualInner.val, val, "the inner's inner should T");
+    t.is(unwrapSome(actualInner), val, "the inner's inner should T");
     t.not(actual, input, 'the outer should be different from the input');
     t.not(actual, inner, "the outer should be different from the input's inner");
     t.not(actualInner, input, 'the inner should be different from the input');
@@ -36,7 +36,7 @@ test('input is None, the result should be Ok(None)', (t) => {
     const input = createNone();
     const actual = transposeOptionToResult(input);
 
-    const actualInner = actual.val;
+    const actualInner = unwrapOk(actual);
 
     t.true(isOk(actual), 'the outer should Ok(None)');
     t.true(isNone(actualInner), 'the inner should be None');

--- a/packages/api_tests/__tests__/plain_result/and.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/and.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { andForResult } from 'option-t/plain_result/and';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 test('a=Ok, b=Ok', (t) => {
     const EXPECTED = Symbol('expected');
@@ -13,8 +20,8 @@ test('a=Ok, b=Ok', (t) => {
     const actual = andForResult(a, b);
 
     t.is(actual, b, 'should return b');
-    t.true(actual.ok, 'should be Ok');
-    t.is(actual.val, EXPECTED, 'should be the inner value');
+    t.true(isOk(actual), 'should be Ok');
+    t.is(unwrapOk(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Ok, b=Err', (t) => {
@@ -27,8 +34,8 @@ test('a=Ok, b=Err', (t) => {
     const actual = andForResult(a, b);
 
     t.is(actual, b, 'should return b');
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, EXPECTED, 'should be the inner value');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Err, b=Ok', (t) => {
@@ -41,8 +48,8 @@ test('a=Err, b=Ok', (t) => {
     const actual = andForResult(a, b);
 
     t.is(actual, a, 'should return a');
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, EXPECTED, 'should be the inner value');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Err, b=Err', (t) => {
@@ -55,6 +62,6 @@ test('a=Err, b=Err', (t) => {
     const actual = andForResult(a, b);
 
     t.is(actual, a, 'should return a');
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, EXPECTED, 'should be the inner value');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });

--- a/packages/api_tests/__tests__/plain_result/and_then.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/and_then.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { andThenForResult } from 'option-t/plain_result/and_then';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const VALUE_U = Math.random();
@@ -17,21 +24,21 @@ test('input is Ok(T), callback return Ok(T)', (t) => {
     });
 
     t.not(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_U);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_U);
 });
 
 test('input is Ok(T), callback return Err(E)', (t) => {
     t.plan(3);
 
     const input = createOk(VALUE_T);
-    const result = andThenForResult(input, (v) => {
+    const actual = andThenForResult(input, (v) => {
         t.is(v, VALUE_T);
         return createErr(ERROR_E);
     });
 
-    t.false(result.ok);
-    t.is(result.err, ERROR_E);
+    t.false(isOk(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });
 
 test('input is Err(E)', (t) => {
@@ -44,6 +51,6 @@ test('input is Err(E)', (t) => {
     });
 
     t.is(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_E);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });

--- a/packages/api_tests/__tests__/plain_result/and_then_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/and_then_async.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { andThenAsyncForResult } from 'option-t/plain_result/and_then_async';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const VALUE_U = Math.random();
@@ -20,8 +27,8 @@ test('input is Ok(T), callback return Ok(T)', async (t) => {
 
     const actual = await result;
     t.not(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_U);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_U);
 });
 
 test('input is Ok(T), callback return Err(E)', async (t) => {
@@ -36,8 +43,8 @@ test('input is Ok(T), callback return Err(E)', async (t) => {
     t.true(result instanceof Promise, 'result should be Promise');
 
     const actual = await result;
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_E);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });
 
 test('input is Err(E)', async (t) => {
@@ -53,6 +60,6 @@ test('input is Err(E)', async (t) => {
 
     const actual = await result;
     t.is(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_E);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });

--- a/packages/api_tests/__tests__/plain_result/create.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/create.test.mjs
@@ -7,7 +7,7 @@ test('PlainResult::createOk', (t) => {
     const actual = PlainResult.createOk(EXPECTED);
 
     t.true(PlainResult.isOk(actual), 'actual should be Ok');
-    t.is(actual.val, EXPECTED, 'actual should be expected');
+    t.is(PlainResult.unwrapOk(actual), EXPECTED, 'actual should be expected');
 });
 
 test('PlainResult::createErr', (t) => {
@@ -15,5 +15,5 @@ test('PlainResult::createErr', (t) => {
     const actual = PlainResult.createErr(EXPECTED);
 
     t.true(PlainResult.isErr(actual), 'actual should be Err');
-    t.is(actual.err, EXPECTED, 'actual should be expected');
+    t.is(PlainResult.unwrapErr(actual), EXPECTED, 'actual should be expected');
 });

--- a/packages/api_tests/__tests__/plain_result/drop/test_drop_both.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/drop/test_drop_both.test.mjs
@@ -2,7 +2,7 @@
 import test from 'ava';
 
 import { unsafeDropBothForResult } from 'option-t/plain_result/drop';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import { createOk, createErr, isOk } from 'option-t/plain_result/result';
 
 test('with Ok', (t) => {
     const expected = Symbol('');
@@ -19,7 +19,7 @@ test('with Ok', (t) => {
         },
     );
 
-    t.is(actual.ok, false, 'should be modified');
+    t.is(isOk(actual), false, 'should be modified');
     t.is(actual.val, undefined, 'should be released');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });
@@ -39,7 +39,7 @@ test('with Err', (t) => {
         },
     );
 
-    t.is(actual.ok, true, 'should be modified');
+    t.is(isOk(actual), true, 'should be modified');
     t.is(actual.err, undefined, 'should be released');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/packages/api_tests/__tests__/plain_result/drop/test_drop_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/drop/test_drop_err.test.mjs
@@ -2,7 +2,7 @@
 import test from 'ava';
 
 import { unsafeDropErrForResult } from 'option-t/plain_result/drop';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import { createOk, createErr, isOk } from 'option-t/plain_result/result';
 
 test('with Ok', (t) => {
     const actual = createOk(1);
@@ -11,7 +11,7 @@ test('with Ok', (t) => {
         t.fail('Do not enter this path.');
     });
 
-    t.is(actual.ok, true, 'should not be modified');
+    t.is(isOk(actual), true, 'should not be modified');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });
 
@@ -24,7 +24,7 @@ test('with Err', (t) => {
         err.err = expected;
     });
 
-    t.is(actual.ok, true, 'should be modified');
+    t.is(isOk(actual), true, 'should be modified');
     t.is(actual.err, undefined, 'should be released');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/packages/api_tests/__tests__/plain_result/drop/test_drop_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/drop/test_drop_ok.test.mjs
@@ -2,7 +2,7 @@
 import test from 'ava';
 
 import { unsafeDropOkForResult } from 'option-t/plain_result/drop';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import { createOk, createErr, isOk, unwrapOk } from 'option-t/plain_result/result';
 
 test('with Ok', (t) => {
     const expected = Symbol('');
@@ -13,7 +13,7 @@ test('with Ok', (t) => {
         ok.val = expected;
     });
 
-    t.is(actual.ok, false, 'should be modified');
+    t.is(isOk(actual), false, 'should be modified');
     t.is(actual.val, undefined, 'should be released');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });
@@ -25,7 +25,7 @@ test('with Err', (t) => {
         t.fail('Do not enter this path.');
     });
 
-    t.is(actual.ok, false, 'should not be modified');
+    t.is(isOk(actual), false, 'should not be modified');
     t.true(Object.isFrozen(actual), 'should be frozen');
 });
 

--- a/packages/api_tests/__tests__/plain_result/flatten.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/flatten.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { flattenForResult } from 'option-t/plain_result/flatten';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 test('input is Ok(Ok(T))', (t) => {
     const VALUE_T = Symbol('value');
@@ -10,8 +17,8 @@ test('input is Ok(Ok(T))', (t) => {
     const input = createOk(inner);
     const actual = flattenForResult(input);
 
-    t.true(actual.ok, 'should be Ok');
-    t.is(actual.val, VALUE_T, 'should be the wrapped value');
+    t.true(isOk(actual), 'should be Ok');
+    t.is(unwrapOk(actual), VALUE_T, 'should be the wrapped value');
 });
 
 test('input is Ok(Err(E))', (t) => {
@@ -21,8 +28,8 @@ test('input is Ok(Err(E))', (t) => {
     const input = createOk(inner);
     const actual = flattenForResult(input);
 
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, VALUE_E, 'should be the wrapped error');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), VALUE_E, 'should be the wrapped error');
 });
 
 test('input is Err(E)', (t) => {
@@ -30,8 +37,8 @@ test('input is Err(E)', (t) => {
     const input = createErr(VALUE_E);
     const actual = flattenForResult(input);
 
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, VALUE_E, 'should be the wrapped error');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), VALUE_E, 'should be the wrapped error');
 });
 
 test('this should remove only one nest level', (t) => {

--- a/packages/api_tests/__tests__/plain_result/map.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/map.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { mapForResult } from 'option-t/plain_result/map';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const VALUE_U = Math.random();
@@ -17,8 +24,8 @@ test('input is Ok(T), callback return T', (t) => {
     });
 
     t.not(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_U);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_U);
 });
 
 test('input is Err(E)', (t) => {
@@ -31,6 +38,6 @@ test('input is Err(E)', (t) => {
     });
 
     t.is(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_E);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });

--- a/packages/api_tests/__tests__/plain_result/map_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/map_async.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { mapAsyncForResult } from 'option-t/plain_result/map_async';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const VALUE_U = Math.random();
@@ -20,8 +27,8 @@ test('input is Ok(T), callback return T', async (t) => {
 
     const actual = await result;
     t.not(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_U);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_U);
 });
 
 test('input is Err(E)', async (t) => {
@@ -37,6 +44,6 @@ test('input is Err(E)', async (t) => {
 
     const actual = await result;
     t.is(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_E);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_E);
 });

--- a/packages/api_tests/__tests__/plain_result/map_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/map_err.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { mapErrForResult } from 'option-t/plain_result/map_err';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const ERROR_E = new Error('e');
@@ -17,8 +24,8 @@ test('input is Ok(T)', (t) => {
     });
 
     t.is(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_T);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_T);
 });
 
 test('input is Err(E)', (t) => {
@@ -31,6 +38,6 @@ test('input is Err(E)', (t) => {
     });
 
     t.not(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_F);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_F);
 });

--- a/packages/api_tests/__tests__/plain_result/map_err_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/map_err_async.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { mapErrAsyncForResult } from 'option-t/plain_result/map_err_async';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 const VALUE_T = Math.random();
 const ERROR_E = new Error('e');
@@ -20,8 +27,8 @@ test('input is Ok(T)', async (t) => {
 
     const actual = await result;
     t.is(actual, input);
-    t.true(actual.ok);
-    t.is(actual.val, VALUE_T);
+    t.true(isOk(actual));
+    t.is(unwrapOk(actual), VALUE_T);
 });
 
 test('input is Err(E)', async (t) => {
@@ -37,6 +44,6 @@ test('input is Err(E)', async (t) => {
 
     const actual = await result;
     t.not(actual, input);
-    t.false(actual.ok);
-    t.is(actual.err, ERROR_F);
+    t.true(isErr(actual));
+    t.is(unwrapErr(actual), ERROR_F);
 });

--- a/packages/api_tests/__tests__/plain_result/or.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/or.test.mjs
@@ -1,7 +1,14 @@
 import test from 'ava';
 
 import { orForResult } from 'option-t/plain_result/or';
-import { createOk, createErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 
 test('a=Ok, b=Ok', (t) => {
     const EXPECTED = Symbol('expected');
@@ -13,8 +20,8 @@ test('a=Ok, b=Ok', (t) => {
     const actual = orForResult(a, b);
 
     t.is(actual, a, 'should return a');
-    t.true(actual.ok, 'should be Ok');
-    t.is(actual.val, EXPECTED, 'should be the inner value');
+    t.true(isOk(actual), 'should be Ok');
+    t.is(unwrapOk(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Ok, b=Err', (t) => {
@@ -27,8 +34,8 @@ test('a=Ok, b=Err', (t) => {
     const actual = orForResult(a, b);
 
     t.is(actual, a, 'should return a');
-    t.true(actual.ok, 'should be Ok');
-    t.is(actual.val, EXPECTED, 'should be the inner value');
+    t.true(isOk(actual), 'should be Ok');
+    t.is(unwrapOk(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Err, b=Ok', (t) => {
@@ -41,8 +48,8 @@ test('a=Err, b=Ok', (t) => {
     const actual = orForResult(a, b);
 
     t.is(actual, b, 'should return b');
-    t.true(actual.ok, 'should be Ok');
-    t.is(actual.val, EXPECTED, 'should be the inner value');
+    t.true(isOk(actual), 'should be Ok');
+    t.is(unwrapOk(actual), EXPECTED, 'should be the inner value');
 });
 
 test('a=Err, b=Err', (t) => {
@@ -55,6 +62,6 @@ test('a=Err, b=Err', (t) => {
     const actual = orForResult(a, b);
 
     t.is(actual, b, 'should return b');
-    t.false(actual.ok, 'should be Err');
-    t.is(actual.err, EXPECTED, 'should be the inner value');
+    t.true(isErr(actual), 'should be Err');
+    t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });

--- a/packages/api_tests/__tests__/plain_result/transpose/to_nullable.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/transpose/to_nullable.test.mjs
@@ -1,6 +1,13 @@
 import test from 'ava';
 
-import { createOk, createErr, isOk, isErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 import { transposeResultToNullable } from 'option-t/plain_result/transpose';
 
 test('input is Ok<T>, the result should be Ok(T)', (t) => {
@@ -8,7 +15,7 @@ test('input is Ok<T>, the result should be Ok(T)', (t) => {
     const input = createOk(val);
     const actual = transposeResultToNullable(input);
     t.true(isOk(actual), 'the inner should Ok<T>');
-    t.is(actual.val, val, "the inner's inner should T");
+    t.is(unwrapOk(actual), val, "the inner's inner should T");
 });
 
 test('input is Ok<null>, the result should be null', (t) => {
@@ -23,5 +30,5 @@ test('input is Err<E>, the result should be Err(e)', (t) => {
     const actual = transposeResultToNullable(input);
 
     t.true(isErr(actual), 'the actual should Err<E>');
-    t.is(actual.err, inner, "the actual's inner should E");
+    t.is(unwrapErr(actual), inner, "the actual's inner should E");
 });

--- a/packages/api_tests/__tests__/plain_result/transpose/to_undefinable.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/transpose/to_undefinable.test.mjs
@@ -1,6 +1,13 @@
 import test from 'ava';
 
-import { createOk, createErr, isOk, isErr } from 'option-t/plain_result/result';
+import {
+    createOk,
+    createErr,
+    isOk,
+    isErr,
+    unwrapOk,
+    unwrapErr,
+} from 'option-t/plain_result/result';
 import { transposeResultToUndefinable } from 'option-t/plain_result/transpose';
 
 test('input is Ok<T>, the result should be Ok(T)', (t) => {
@@ -8,7 +15,7 @@ test('input is Ok<T>, the result should be Ok(T)', (t) => {
     const input = createOk(val);
     const actual = transposeResultToUndefinable(input);
     t.true(isOk(actual), 'the inner should Ok<T>');
-    t.is(actual.val, val, "the inner's inner should T");
+    t.is(unwrapOk(actual), val, "the inner's inner should T");
 });
 
 test('input is Ok<null>, the result should be undefined', (t) => {
@@ -23,5 +30,5 @@ test('input is Err<E>, the result should be Err(e)', (t) => {
     const actual = transposeResultToUndefinable(input);
 
     t.true(isErr(actual), 'the actual should Err<E>');
-    t.is(actual.err, inner, "the actual's inner should E");
+    t.is(unwrapErr(actual), inner, "the actual's inner should E");
 });


### PR DESCRIPTION
For the future refactoring #2244, we change to avoid touch object properties directly.