### PR TITLE
ci: Add Node v23 for unint test job

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -89,6 +89,7 @@ jobs:
                 node-version:
                     - 20
                     - 22
+                    - 23
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v23.0.0