### PR TITLE
Remove unnecessary `always-auth` from .npmrc

### DIFF
--- a/tools/publish/.npmrc
+++ b/tools/publish/.npmrc
@@ -1,3 +1,2 @@
 //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 registry=https://registry.npmjs.org/
-always-auth=true


### PR DESCRIPTION
This option was removed since v7
https://docs.npmjs.com/cli/v6/using-npm/config