### PR TITLE
ci: Drop legacy Node.js from unittest jobs

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -87,8 +87,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - ">=22.12.0"
-                    - 23
                     - 24
 
         steps:


### PR DESCRIPTION
We dropped to support for them in https://github.com/option-t/option-t/pull/2531