### PR TITLE
dependabot: Add `cooldown` setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       directory: "/"
       schedule:
           interval: monthly
+      cooldown:
+          default-days: 7 # This 1-week delay is just by my intuition.
+          include:
+              - "*"
       open-pull-requests-limit: 99
       labels:
           - A-dependency
@@ -39,6 +43,10 @@ updates:
       directory: "/"
       schedule:
           interval: monthly
+      cooldown:
+          default-days: 7 # This 1-week delay is just by my intuition.
+          include:
+              - "*"
       open-pull-requests-limit: 99
       labels:
           - A-dependency
@@ -51,6 +59,10 @@ updates:
       directory: "/.github/actions/prepare_ci/"
       schedule:
           interval: monthly
+      cooldown:
+          default-days: 7 # This 1-week delay is just by my intuition.
+          include:
+              - "*"
       open-pull-requests-limit: 99
       labels:
           - A-dependency


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2570

This aims to mitigate a supply chain attack risk happens frequently recently. 1-week delay is judged by just my intuition as heuristic.

- https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-