### PR TITLE
Remove unnecessary npmrc copying step for publishing

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -23,6 +23,7 @@ runs:
           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
           with:
               node-version: ${{ inputs.node-version }}
+              registry-url: "https://registry.npmjs.org"
         - name: Activate corepack
           shell: bash
           run: | # This workaround https://github.com/nodejs/corepack/issues/612

--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -20,7 +20,6 @@ jobs:
             - uses: ./.github/actions/prepare_ci
               with:
                   node-version: 24
-                  registry-url: "https://registry.npmjs.org"
             # Trusted publishing requires npm CLI version 11.5.1 or later.
             - name: Install latest npm
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store*
-.npmrc
 npm-debug.log
 
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ NPM_BIN := $(NPM_MOD_DIR)/.bin
 NPM_CMD := npm
 PNPM_CMD := pnpm
 
-PROJECT_NPMRC := $(DIST_DIR)/.npmrc
 PROJECT_TURBO_DIR := $(CURDIR)/.turbo
 
 all: help
@@ -42,11 +41,7 @@ clean_main_pkg:
 	$(MAKE) clean -C $(MAIN_PKG)
 
 .PHONY: clean_repo_root
-clean_repo_root: clean_npmrc clean_turborepo_cache
-
-.PHONY: clean_npmrc
-clean_npmrc:
-	$(NPM_BIN)/del $(PROJECT_NPMRC)
+clean_repo_root: clean_turborepo_cache
 
 .PHONY: clean_turborepo_cache
 clean_turborepo_cache:
@@ -151,12 +146,8 @@ prepublish:
 	$(MAKE) run_test_import_types -C $(CURDIR)
 
 .PHONY: publish
-publish: copy_npmrc_to_project_root ## Run some commands for 'npm publish'
+publish: ## Run some commands for 'npm publish'
 	$(MAKE) $@ -C $(MAIN_PKG)
-
-.PHONY: copy_npmrc_to_project_root
-copy_npmrc_to_project_root: clean_npmrc
-	cp $(CURDIR)/tools/publish/.npmrc $(PROJECT_NPMRC)
 
 .PHONY: git_diff
 git_diff: ## Test whether there is no committed changes.

--- a/tools/publish/.npmrc
+++ b/tools/publish/.npmrc
@@ -1,2 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
By https://github.com/option-t/option-t/issues/2582, we can do this.