### PR TITLE
Remove `@deprecated` jsdoc tag from `option-t/<type_name>/compat/v54`

### DIFF
--- a/packages/option-t/src/maybe/compat/v54.ts
+++ b/packages/option-t/src/maybe/compat/v54.ts
@@ -1,6 +1,5 @@
 /**
- *  @deprecated
- *  Please migrate to:
+ *  Please migrate your codes to:
  *      1. `MaybeOperator` of `option-t/maybe`.
  *      2. Import `option-t/maybe/***` directly.
  */

--- a/packages/option-t/src/nullable/compat/v54.ts
+++ b/packages/option-t/src/nullable/compat/v54.ts
@@ -1,6 +1,5 @@
 /**
- *  @deprecated
- *  Please migrate to:
+ *  Please migrate your codes to:
  *      1. `NullableOperator` of `option-t/nullable`.
  *      2. Import `option-t/nullable/***` directly.
  */

--- a/packages/option-t/src/plain_result/compat/v54.ts
+++ b/packages/option-t/src/plain_result/compat/v54.ts
@@ -1,6 +1,5 @@
 /**
- *  @deprecated
- *  Please migrate to:
+ *  Please migrate your codes to:
  *      1. `ResultOperator` or `ResultFactory` of `option-t/plain_result`.
  *      2. Import `option-t/plain_result/***` directly.
  */

--- a/packages/option-t/src/undefinable/compat/v54.ts
+++ b/packages/option-t/src/undefinable/compat/v54.ts
@@ -1,6 +1,5 @@
 /**
- *  @deprecated
- *  Please migrate to:
+ *  Please migrate your codes to:
  *      1. `UndefinableOperator` of `option-t/undefinable`.
  *      2. Import `option-t/undefinable/***` directly.
  */


### PR DESCRIPTION
I guess we cannot remove this module path  for backward compat...