### PR TITLE
ci: Use `$` syntax to specify in-repository github actions

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -46,7 +46,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make format_check -j
@@ -69,7 +69,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make lint -j
@@ -92,7 +92,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make build -j
@@ -116,7 +116,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make test_unittest -j
@@ -139,7 +139,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make test_api_typing -j
@@ -161,7 +161,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make test_package_json_exports_field_format -j
@@ -183,7 +183,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make test_import_types -j
@@ -206,7 +206,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: ${{ matrix.node-version }}
             - run: make test_distribution_contain_all -j

--- a/.github/workflows/ci_for_merge_queue.yaml
+++ b/.github/workflows/ci_for_merge_queue.yaml
@@ -10,6 +10,6 @@ permissions: {}
 
 jobs:
     ci:
-        uses: ./.github/workflows/_ci.yaml
+        uses: $/.github/workflows/_ci.yaml
         permissions:
             contents: read

--- a/.github/workflows/ci_for_pr.yaml
+++ b/.github/workflows/ci_for_pr.yaml
@@ -12,6 +12,6 @@ concurrency:
 
 jobs:
     ci:
-        uses: ./.github/workflows/_ci.yaml
+        uses: $/.github/workflows/_ci.yaml
         permissions:
             contents: read

--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -9,6 +9,6 @@ permissions: {}
 
 jobs:
     ci:
-        uses: ./.github/workflows/_ci.yaml
+        uses: $/.github/workflows/_ci.yaml
         permissions:
             contents: read

--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -20,7 +20,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: ./.github/actions/prepare_ci
+            - uses: $/.github/actions/prepare_ci
               with:
                   node-version: 24
             - run: pnpm ci


### PR DESCRIPTION
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow-at-the-running-commit-recommended
- https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/